### PR TITLE
Utililize go i2p logger

### DIFF
--- a/common.go
+++ b/common.go
@@ -62,28 +62,28 @@ var TLS_KEYSTORE_PATH = tlsdefault
 // path is not set, it returns the default path. If the path does
 // not exist, it creates it.
 func I2PKeystorePath() (string, error) {
-	log.WithField("path", I2P_KEYSTORE_PATH).Debug("Checking I2P keystore path")
+	i2plog.WithField("path", I2P_KEYSTORE_PATH).Debug("Checking I2P keystore path")
 	if _, err := os.Stat(I2P_KEYSTORE_PATH); err != nil {
-		log.WithField("path", I2P_KEYSTORE_PATH).Debug("I2P keystore directory does not exist, creating")
+		i2plog.WithField("path", I2P_KEYSTORE_PATH).Debug("I2P keystore directory does not exist, creating")
 		err := os.MkdirAll(I2P_KEYSTORE_PATH, 0755)
 		if err != nil {
-			log.WithError(err).WithField("path", I2P_KEYSTORE_PATH).Error("Failed to create I2P keystore directory")
+			i2plog.WithError(err).WithField("path", I2P_KEYSTORE_PATH).Error("Failed to create I2P keystore directory")
 			return "", err
 		}
 	}
-	log.WithField("path", I2P_KEYSTORE_PATH).Debug("I2P keystore path verified")
+	i2plog.WithField("path", I2P_KEYSTORE_PATH).Debug("I2P keystore path verified")
 	return I2P_KEYSTORE_PATH, nil
 }
 
 // DeleteI2PKeyStore deletes the I2P Keystore.
 func DeleteI2PKeyStore() error {
-	log.WithField("path", I2P_KEYSTORE_PATH).Debug("Attempting to delete I2P keystore")
+	i2plog.WithField("path", I2P_KEYSTORE_PATH).Debug("Attempting to delete I2P keystore")
 	err := os.RemoveAll(I2P_KEYSTORE_PATH)
 	if err != nil {
-		log.WithError(err).WithField("path", I2P_KEYSTORE_PATH).Error("Failed to delete I2P keystore")
+		i2plog.WithError(err).WithField("path", I2P_KEYSTORE_PATH).Error("Failed to delete I2P keystore")
 		return err
 	}
-	log.WithField("path", I2P_KEYSTORE_PATH).Debug("Successfully deleted I2P keystore")
+	i2plog.WithField("path", I2P_KEYSTORE_PATH).Debug("Successfully deleted I2P keystore")
 	return nil
 	//return os.RemoveAll(I2P_KEYSTORE_PATH)
 }
@@ -92,28 +92,28 @@ func DeleteI2PKeyStore() error {
 // path is not set, it returns the default path. If the path does
 // not exist, it creates it.
 func TorKeystorePath() (string, error) {
-	log.WithField("path", ONION_KEYSTORE_PATH).Debug("Checking Tor keystore path")
+	i2plog.WithField("path", ONION_KEYSTORE_PATH).Debug("Checking Tor keystore path")
 	if _, err := os.Stat(ONION_KEYSTORE_PATH); err != nil {
-		log.WithField("path", ONION_KEYSTORE_PATH).Debug("Tor keystore directory does not exist, creating")
+		i2plog.WithField("path", ONION_KEYSTORE_PATH).Debug("Tor keystore directory does not exist, creating")
 		err := os.MkdirAll(ONION_KEYSTORE_PATH, 0755)
 		if err != nil {
-			log.WithError(err).WithField("path", ONION_KEYSTORE_PATH).Error("Failed to create Tor keystore directory")
+			i2plog.WithError(err).WithField("path", ONION_KEYSTORE_PATH).Error("Failed to create Tor keystore directory")
 			return "", err
 		}
 	}
-	log.WithField("path", ONION_KEYSTORE_PATH).Debug("Tor keystore path verified")
+	i2plog.WithField("path", ONION_KEYSTORE_PATH).Debug("Tor keystore path verified")
 	return ONION_KEYSTORE_PATH, nil
 }
 
 // DeleteTorKeyStore deletes the Onion Keystore.
 func DeleteTorKeyStore() error {
-	log.WithField("path", ONION_KEYSTORE_PATH).Debug("Attempting to delete Tor keystore")
+	i2plog.WithField("path", ONION_KEYSTORE_PATH).Debug("Attempting to delete Tor keystore")
 	err := os.RemoveAll(ONION_KEYSTORE_PATH)
 	if err != nil {
-		log.WithError(err).WithField("path", ONION_KEYSTORE_PATH).Error("Failed to delete Tor keystore")
+		i2plog.WithError(err).WithField("path", ONION_KEYSTORE_PATH).Error("Failed to delete Tor keystore")
 		return err
 	}
-	log.WithField("path", ONION_KEYSTORE_PATH).Debug("Successfully deleted Tor keystore")
+	i2plog.WithField("path", ONION_KEYSTORE_PATH).Debug("Successfully deleted Tor keystore")
 	return nil
 	//return os.RemoveAll(ONION_KEYSTORE_PATH)
 }
@@ -122,28 +122,28 @@ func DeleteTorKeyStore() error {
 // path is not set, it returns the default path. If the path does
 // not exist, it creates it.
 func TLSKeystorePath() (string, error) {
-	log.WithField("path", TLS_KEYSTORE_PATH).Debug("Checking TLS keystore path")
+	i2plog.WithField("path", TLS_KEYSTORE_PATH).Debug("Checking TLS keystore path")
 	if _, err := os.Stat(TLS_KEYSTORE_PATH); err != nil {
-		log.WithField("path", TLS_KEYSTORE_PATH).Debug("TLS keystore directory does not exist, creating")
+		i2plog.WithField("path", TLS_KEYSTORE_PATH).Debug("TLS keystore directory does not exist, creating")
 		err := os.MkdirAll(TLS_KEYSTORE_PATH, 0755)
 		if err != nil {
-			log.WithError(err).WithField("path", TLS_KEYSTORE_PATH).Error("Failed to create TLS keystore directory")
+			i2plog.WithError(err).WithField("path", TLS_KEYSTORE_PATH).Error("Failed to create TLS keystore directory")
 			return "", err
 		}
 	}
-	log.WithField("path", TLS_KEYSTORE_PATH).Debug("TLS keystore path verified")
+	i2plog.WithField("path", TLS_KEYSTORE_PATH).Debug("TLS keystore path verified")
 	return TLS_KEYSTORE_PATH, nil
 }
 
 // DeleteTLSKeyStore deletes the TLS Keystore.
 func DeleteTLSKeyStore() error {
-	log.WithField("path", TLS_KEYSTORE_PATH).Debug("Attempting to delete TLS keystore")
+	i2plog.WithField("path", TLS_KEYSTORE_PATH).Debug("Attempting to delete TLS keystore")
 	err := os.RemoveAll(TLS_KEYSTORE_PATH)
 	if err != nil {
-		log.WithError(err).WithField("path", TLS_KEYSTORE_PATH).Error("Failed to delete TLS keystore")
+		i2plog.WithError(err).WithField("path", TLS_KEYSTORE_PATH).Error("Failed to delete TLS keystore")
 		return err
 	}
-	log.WithField("path", TLS_KEYSTORE_PATH).Debug("Successfully deleted TLS keystore")
+	i2plog.WithField("path", TLS_KEYSTORE_PATH).Debug("Successfully deleted TLS keystore")
 	return nil
 	//return os.RemoveAll(TLS_KEYSTORE_PATH)
 }
@@ -152,22 +152,22 @@ func DeleteTLSKeyStore() error {
 // network is ignored. If the address ends in i2p, it returns an I2P connection.
 // if the address ends in anything else, it returns a Tor connection.
 func Dial(network, addr string) (net.Conn, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"network": network,
 		"address": addr,
 	}).Debug("Attempting to dial")
 
 	url, err := url.Parse(addr)
 	if err != nil {
-		log.WithError(err).WithField("address", addr).Error("Failed to parse address")
+		i2plog.WithError(err).WithField("address", addr).Error("Failed to parse address")
 		return nil, err
 	}
 	hostname := url.Hostname()
 	if strings.HasSuffix(hostname, ".i2p") {
-		log.WithField("hostname", hostname).Debug("Using I2P connection for .i2p address")
+		i2plog.WithField("hostname", hostname).Debug("Using I2P connection for .i2p address")
 		return DialGarlic(network, addr)
 	}
-	log.WithField("hostname", hostname).Debug("Using Tor connection for non-i2p address")
+	i2plog.WithField("hostname", hostname).Debug("Using Tor connection for non-i2p address")
 	return DialOnion(network, addr)
 }
 
@@ -176,31 +176,31 @@ func Dial(network, addr string) (net.Conn, error) {
 // if network is tor or onion, it returns an Onion listener.
 // if keys ends with ".i2p", it returns an I2P listener.
 func Listen(network, keys string) (net.Listener, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"network": network,
 		"keys":    keys,
 	}).Debug("Attempting to create listener")
 
 	if network == "i2p" || network == "garlic" {
-		log.Debug("Creating I2P listener based on network type")
+		i2plog.Debug("Creating I2P listener based on network type")
 		return ListenGarlic(network, keys)
 	}
 	if network == "tor" || network == "onion" {
-		log.Debug("Creating Tor listener based on network type")
+		i2plog.Debug("Creating Tor listener based on network type")
 		return ListenOnion(network, keys)
 	}
 
 	url, err := url.Parse(keys)
 	if err != nil {
-		log.WithError(err).WithField("keys", keys).Error("Failed to parse keys URL")
+		i2plog.WithError(err).WithField("keys", keys).Error("Failed to parse keys URL")
 		return nil, err
 	}
 
 	hostname := url.Hostname()
 	if strings.HasSuffix(hostname, ".i2p") {
-		log.WithField("hostname", hostname).Debug("Creating I2P listener based on .i2p hostname")
+		i2plog.WithField("hostname", hostname).Debug("Creating I2P listener based on .i2p hostname")
 		return ListenGarlic(network, keys)
 	}
-	log.WithField("hostname", hostname).Debug("Creating Tor listener for non-i2p hostname")
+	i2plog.WithField("hostname", hostname).Debug("Creating Tor listener for non-i2p hostname")
 	return ListenOnion(network, keys)
 }

--- a/common.go
+++ b/common.go
@@ -62,28 +62,28 @@ var TLS_KEYSTORE_PATH = tlsdefault
 // path is not set, it returns the default path. If the path does
 // not exist, it creates it.
 func I2PKeystorePath() (string, error) {
-	i2plog.WithField("path", I2P_KEYSTORE_PATH).Debug("Checking I2P keystore path")
+	i2pLogger.WithField("path", I2P_KEYSTORE_PATH).Debug("Checking I2P keystore path")
 	if _, err := os.Stat(I2P_KEYSTORE_PATH); err != nil {
-		i2plog.WithField("path", I2P_KEYSTORE_PATH).Debug("I2P keystore directory does not exist, creating")
+		i2pLogger.WithField("path", I2P_KEYSTORE_PATH).Debug("I2P keystore directory does not exist, creating")
 		err := os.MkdirAll(I2P_KEYSTORE_PATH, 0755)
 		if err != nil {
-			i2plog.WithError(err).WithField("path", I2P_KEYSTORE_PATH).Error("Failed to create I2P keystore directory")
+			i2pLogger.WithError(err).WithField("path", I2P_KEYSTORE_PATH).Error("Failed to create I2P keystore directory")
 			return "", err
 		}
 	}
-	i2plog.WithField("path", I2P_KEYSTORE_PATH).Debug("I2P keystore path verified")
+	i2pLogger.WithField("path", I2P_KEYSTORE_PATH).Debug("I2P keystore path verified")
 	return I2P_KEYSTORE_PATH, nil
 }
 
 // DeleteI2PKeyStore deletes the I2P Keystore.
 func DeleteI2PKeyStore() error {
-	i2plog.WithField("path", I2P_KEYSTORE_PATH).Debug("Attempting to delete I2P keystore")
+	i2pLogger.WithField("path", I2P_KEYSTORE_PATH).Debug("Attempting to delete I2P keystore")
 	err := os.RemoveAll(I2P_KEYSTORE_PATH)
 	if err != nil {
-		i2plog.WithError(err).WithField("path", I2P_KEYSTORE_PATH).Error("Failed to delete I2P keystore")
+		i2pLogger.WithError(err).WithField("path", I2P_KEYSTORE_PATH).Error("Failed to delete I2P keystore")
 		return err
 	}
-	i2plog.WithField("path", I2P_KEYSTORE_PATH).Debug("Successfully deleted I2P keystore")
+	i2pLogger.WithField("path", I2P_KEYSTORE_PATH).Debug("Successfully deleted I2P keystore")
 	return nil
 	//return os.RemoveAll(I2P_KEYSTORE_PATH)
 }
@@ -92,28 +92,28 @@ func DeleteI2PKeyStore() error {
 // path is not set, it returns the default path. If the path does
 // not exist, it creates it.
 func TorKeystorePath() (string, error) {
-	i2plog.WithField("path", ONION_KEYSTORE_PATH).Debug("Checking Tor keystore path")
+	i2pLogger.WithField("path", ONION_KEYSTORE_PATH).Debug("Checking Tor keystore path")
 	if _, err := os.Stat(ONION_KEYSTORE_PATH); err != nil {
-		i2plog.WithField("path", ONION_KEYSTORE_PATH).Debug("Tor keystore directory does not exist, creating")
+		i2pLogger.WithField("path", ONION_KEYSTORE_PATH).Debug("Tor keystore directory does not exist, creating")
 		err := os.MkdirAll(ONION_KEYSTORE_PATH, 0755)
 		if err != nil {
-			i2plog.WithError(err).WithField("path", ONION_KEYSTORE_PATH).Error("Failed to create Tor keystore directory")
+			i2pLogger.WithError(err).WithField("path", ONION_KEYSTORE_PATH).Error("Failed to create Tor keystore directory")
 			return "", err
 		}
 	}
-	i2plog.WithField("path", ONION_KEYSTORE_PATH).Debug("Tor keystore path verified")
+	i2pLogger.WithField("path", ONION_KEYSTORE_PATH).Debug("Tor keystore path verified")
 	return ONION_KEYSTORE_PATH, nil
 }
 
 // DeleteTorKeyStore deletes the Onion Keystore.
 func DeleteTorKeyStore() error {
-	i2plog.WithField("path", ONION_KEYSTORE_PATH).Debug("Attempting to delete Tor keystore")
+	i2pLogger.WithField("path", ONION_KEYSTORE_PATH).Debug("Attempting to delete Tor keystore")
 	err := os.RemoveAll(ONION_KEYSTORE_PATH)
 	if err != nil {
-		i2plog.WithError(err).WithField("path", ONION_KEYSTORE_PATH).Error("Failed to delete Tor keystore")
+		i2pLogger.WithError(err).WithField("path", ONION_KEYSTORE_PATH).Error("Failed to delete Tor keystore")
 		return err
 	}
-	i2plog.WithField("path", ONION_KEYSTORE_PATH).Debug("Successfully deleted Tor keystore")
+	i2pLogger.WithField("path", ONION_KEYSTORE_PATH).Debug("Successfully deleted Tor keystore")
 	return nil
 	//return os.RemoveAll(ONION_KEYSTORE_PATH)
 }
@@ -122,28 +122,28 @@ func DeleteTorKeyStore() error {
 // path is not set, it returns the default path. If the path does
 // not exist, it creates it.
 func TLSKeystorePath() (string, error) {
-	i2plog.WithField("path", TLS_KEYSTORE_PATH).Debug("Checking TLS keystore path")
+	i2pLogger.WithField("path", TLS_KEYSTORE_PATH).Debug("Checking TLS keystore path")
 	if _, err := os.Stat(TLS_KEYSTORE_PATH); err != nil {
-		i2plog.WithField("path", TLS_KEYSTORE_PATH).Debug("TLS keystore directory does not exist, creating")
+		i2pLogger.WithField("path", TLS_KEYSTORE_PATH).Debug("TLS keystore directory does not exist, creating")
 		err := os.MkdirAll(TLS_KEYSTORE_PATH, 0755)
 		if err != nil {
-			i2plog.WithError(err).WithField("path", TLS_KEYSTORE_PATH).Error("Failed to create TLS keystore directory")
+			i2pLogger.WithError(err).WithField("path", TLS_KEYSTORE_PATH).Error("Failed to create TLS keystore directory")
 			return "", err
 		}
 	}
-	i2plog.WithField("path", TLS_KEYSTORE_PATH).Debug("TLS keystore path verified")
+	i2pLogger.WithField("path", TLS_KEYSTORE_PATH).Debug("TLS keystore path verified")
 	return TLS_KEYSTORE_PATH, nil
 }
 
 // DeleteTLSKeyStore deletes the TLS Keystore.
 func DeleteTLSKeyStore() error {
-	i2plog.WithField("path", TLS_KEYSTORE_PATH).Debug("Attempting to delete TLS keystore")
+	i2pLogger.WithField("path", TLS_KEYSTORE_PATH).Debug("Attempting to delete TLS keystore")
 	err := os.RemoveAll(TLS_KEYSTORE_PATH)
 	if err != nil {
-		i2plog.WithError(err).WithField("path", TLS_KEYSTORE_PATH).Error("Failed to delete TLS keystore")
+		i2pLogger.WithError(err).WithField("path", TLS_KEYSTORE_PATH).Error("Failed to delete TLS keystore")
 		return err
 	}
-	i2plog.WithField("path", TLS_KEYSTORE_PATH).Debug("Successfully deleted TLS keystore")
+	i2pLogger.WithField("path", TLS_KEYSTORE_PATH).Debug("Successfully deleted TLS keystore")
 	return nil
 	//return os.RemoveAll(TLS_KEYSTORE_PATH)
 }
@@ -152,22 +152,22 @@ func DeleteTLSKeyStore() error {
 // network is ignored. If the address ends in i2p, it returns an I2P connection.
 // if the address ends in anything else, it returns a Tor connection.
 func Dial(network, addr string) (net.Conn, error) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"network": network,
 		"address": addr,
 	}).Debug("Attempting to dial")
 
 	url, err := url.Parse(addr)
 	if err != nil {
-		i2plog.WithError(err).WithField("address", addr).Error("Failed to parse address")
+		i2pLogger.WithError(err).WithField("address", addr).Error("Failed to parse address")
 		return nil, err
 	}
 	hostname := url.Hostname()
 	if strings.HasSuffix(hostname, ".i2p") {
-		i2plog.WithField("hostname", hostname).Debug("Using I2P connection for .i2p address")
+		i2pLogger.WithField("hostname", hostname).Debug("Using I2P connection for .i2p address")
 		return DialGarlic(network, addr)
 	}
-	i2plog.WithField("hostname", hostname).Debug("Using Tor connection for non-i2p address")
+	i2pLogger.WithField("hostname", hostname).Debug("Using Tor connection for non-i2p address")
 	return DialOnion(network, addr)
 }
 
@@ -176,31 +176,31 @@ func Dial(network, addr string) (net.Conn, error) {
 // if network is tor or onion, it returns an Onion listener.
 // if keys ends with ".i2p", it returns an I2P listener.
 func Listen(network, keys string) (net.Listener, error) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"network": network,
 		"keys":    keys,
 	}).Debug("Attempting to create listener")
 
 	if network == "i2p" || network == "garlic" {
-		i2plog.Debug("Creating I2P listener based on network type")
+		i2pLogger.Debug("Creating I2P listener based on network type")
 		return ListenGarlic(network, keys)
 	}
 	if network == "tor" || network == "onion" {
-		i2plog.Debug("Creating Tor listener based on network type")
+		i2pLogger.Debug("Creating Tor listener based on network type")
 		return ListenOnion(network, keys)
 	}
 
 	url, err := url.Parse(keys)
 	if err != nil {
-		i2plog.WithError(err).WithField("keys", keys).Error("Failed to parse keys URL")
+		i2pLogger.WithError(err).WithField("keys", keys).Error("Failed to parse keys URL")
 		return nil, err
 	}
 
 	hostname := url.Hostname()
 	if strings.HasSuffix(hostname, ".i2p") {
-		i2plog.WithField("hostname", hostname).Debug("Creating I2P listener based on .i2p hostname")
+		i2pLogger.WithField("hostname", hostname).Debug("Creating I2P listener based on .i2p hostname")
 		return ListenGarlic(network, keys)
 	}
-	i2plog.WithField("hostname", hostname).Debug("Creating Tor listener for non-i2p hostname")
+	i2pLogger.WithField("hostname", hostname).Debug("Creating Tor listener for non-i2p hostname")
 	return ListenOnion(network, keys)
 }

--- a/garlic.go
+++ b/garlic.go
@@ -101,35 +101,35 @@ func (g *Garlic) getOptions() []string {
 
 func (g *Garlic) samSession() (*sam3.SAM, error) {
 	if g.SAM == nil {
-		i2plog.WithField("address", g.getAddr()).Debug("Creating new SAM session")
+		i2pLogger.WithField("address", g.getAddr()).Debug("Creating new SAM session")
 		var err error
 		g.SAM, err = sam3.NewSAM(g.getAddr())
 		if err != nil {
-			i2plog.WithError(err).Error("Failed to create SAM session")
+			i2pLogger.WithError(err).Error("Failed to create SAM session")
 			return nil, fmt.Errorf("onramp samSession: %v", err)
 		}
-		i2plog.Debug("SAM session created successfully")
+		i2pLogger.Debug("SAM session created successfully")
 	}
 	return g.SAM, nil
 }
 
 func (g *Garlic) setupStreamSession() (*sam3.StreamSession, error) {
 	if g.StreamSession == nil {
-		i2plog.WithField("name", g.getName()).Debug("Setting up stream session")
+		i2pLogger.WithField("name", g.getName()).Debug("Setting up stream session")
 		var err error
 		g.ServiceKeys, err = g.Keys()
 		if err != nil {
-			i2plog.WithError(err).Error("Failed to get keys for stream session")
+			i2pLogger.WithError(err).Error("Failed to get keys for stream session")
 			return nil, fmt.Errorf("onramp setupStreamSession: %v", err)
 		}
-		i2plog.WithField("address", g.ServiceKeys.Address.Base32()).Debug("Creating stream session with keys")
-		i2plog.Println("Creating stream session with keys:", g.ServiceKeys.Address.Base32())
+		i2pLogger.WithField("address", g.ServiceKeys.Address.Base32()).Debug("Creating stream session with keys")
+		i2pLogger.Println("Creating stream session with keys:", g.ServiceKeys.Address.Base32())
 		g.StreamSession, err = g.SAM.NewStreamSession(g.getName(), *g.ServiceKeys, g.getOptions())
 		if err != nil {
-			i2plog.WithError(err).Error("Failed to create stream session")
+			i2pLogger.WithError(err).Error("Failed to create stream session")
 			return nil, fmt.Errorf("onramp setupStreamSession: %v", err)
 		}
-		i2plog.Debug("Stream session created successfully")
+		i2pLogger.Debug("Stream session created successfully")
 		return g.StreamSession, nil
 	}
 	return g.StreamSession, nil
@@ -137,43 +137,43 @@ func (g *Garlic) setupStreamSession() (*sam3.StreamSession, error) {
 
 func (g *Garlic) setupDatagramSession() (*sam3.DatagramSession, error) {
 	if g.DatagramSession == nil {
-		i2plog.WithField("name", g.getName()).Debug("Setting up datagram session")
+		i2pLogger.WithField("name", g.getName()).Debug("Setting up datagram session")
 		var err error
 		g.ServiceKeys, err = g.Keys()
 		if err != nil {
-			i2plog.WithError(err).Error("Failed to get keys for datagram session")
+			i2pLogger.WithError(err).Error("Failed to get keys for datagram session")
 			return nil, fmt.Errorf("onramp setupDatagramSession: %v", err)
 		}
-		i2plog.WithField("address", g.ServiceKeys.Address.Base32()).Debug("Creating datagram session with keys")
-		i2plog.Println("Creating datagram session with keys:", g.ServiceKeys.Address.Base32())
+		i2pLogger.WithField("address", g.ServiceKeys.Address.Base32()).Debug("Creating datagram session with keys")
+		i2pLogger.Println("Creating datagram session with keys:", g.ServiceKeys.Address.Base32())
 		g.DatagramSession, err = g.SAM.NewDatagramSession(g.getName(), *g.ServiceKeys, g.getOptions(), 0)
 		if err != nil {
-			i2plog.WithError(err).Error("Failed to create datagram session")
+			i2pLogger.WithError(err).Error("Failed to create datagram session")
 			return nil, fmt.Errorf("onramp setupDatagramSession: %v", err)
 		}
-		i2plog.Debug("Datagram session created successfully")
+		i2pLogger.Debug("Datagram session created successfully")
 		return g.DatagramSession, nil
 	}
 
-	i2plog.Debug("Using existing datagram session")
+	i2pLogger.Debug("Using existing datagram session")
 	return g.DatagramSession, nil
 }
 
 // NewListener returns a net.Listener for the Garlic structure's I2P keys.
 // accepts a variable list of arguments, arguments after the first one are ignored.
 func (g *Garlic) NewListener(n, addr string) (net.Listener, error) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"network": n,
 		"address": addr,
 		"name":    g.getName(),
 	}).Debug("Creating new listener")
 	listener, err := g.Listen(n)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to create listener")
+		i2pLogger.WithError(err).Error("Failed to create listener")
 		return nil, err
 	}
 
-	i2plog.Debug("Successfully created listener")
+	i2pLogger.Debug("Successfully created listener")
 	return listener, nil
 	// return g.Listen(n)
 }
@@ -181,18 +181,18 @@ func (g *Garlic) NewListener(n, addr string) (net.Listener, error) {
 // Listen returns a net.Listener for the Garlic structure's I2P keys.
 // accepts a variable list of arguments, arguments after the first one are ignored.
 func (g *Garlic) Listen(args ...string) (net.Listener, error) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"args": args,
 		"name": g.getName(),
 	}).Debug("Setting up listener")
 
 	listener, err := g.OldListen(args...)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to create listener")
+		i2pLogger.WithError(err).Error("Failed to create listener")
 		return nil, err
 	}
 
-	i2plog.Debug("Successfully created listener")
+	i2pLogger.Debug("Successfully created listener")
 	return listener, nil
 	// return g.OldListen(args...)
 }
@@ -200,68 +200,68 @@ func (g *Garlic) Listen(args ...string) (net.Listener, error) {
 // OldListen returns a net.Listener for the Garlic structure's I2P keys.
 // accepts a variable list of arguments, arguments after the first one are ignored.
 func (g *Garlic) OldListen(args ...string) (net.Listener, error) {
-	i2plog.WithField("args", args).Debug("Starting OldListen")
+	i2pLogger.WithField("args", args).Debug("Starting OldListen")
 	if len(args) > 0 {
 		protocol := args[0]
-		i2plog.WithField("protocol", protocol).Debug("Checking protocol type")
+		i2pLogger.WithField("protocol", protocol).Debug("Checking protocol type")
 		// if args[0] == "tcp" || args[0] == "tcp6" || args[0] == "st" || args[0] == "st6" {
 		if protocol == "tcp" || protocol == "tcp6" || protocol == "st" || protocol == "st6" {
-			i2plog.Debug("Using TCP stream listener")
+			i2pLogger.Debug("Using TCP stream listener")
 			return g.ListenStream()
 			//} else if args[0] == "udp" || args[0] == "udp6" || args[0] == "dg" || args[0] == "dg6" {
 		} else if protocol == "udp" || protocol == "udp6" || protocol == "dg" || protocol == "dg6" {
-			i2plog.Debug("Using UDP datagram listener")
+			i2pLogger.Debug("Using UDP datagram listener")
 			pk, err := g.ListenPacket()
 			if err != nil {
-				i2plog.WithError(err).Error("Failed to create packet listener")
+				i2pLogger.WithError(err).Error("Failed to create packet listener")
 				return nil, err
 			}
-			i2plog.Debug("Successfully created datagram session")
+			i2pLogger.Debug("Successfully created datagram session")
 			return pk.(*sam3.DatagramSession), nil
 		}
 
 	}
-	i2plog.Debug("No protocol specified, defaulting to stream listener")
+	i2pLogger.Debug("No protocol specified, defaulting to stream listener")
 	return g.ListenStream()
 }
 
 // Listen returns a net.Listener for the Garlic structure's I2P keys.
 func (g *Garlic) ListenStream() (net.Listener, error) {
-	i2plog.Debug("Setting up stream listener")
+	i2pLogger.Debug("Setting up stream listener")
 	var err error
 	if g.SAM, err = g.samSession(); err != nil {
-		i2plog.WithError(err).Error("Failed to create SAM session for stream listener")
+		i2pLogger.WithError(err).Error("Failed to create SAM session for stream listener")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 	if g.StreamSession, err = g.setupStreamSession(); err != nil {
-		i2plog.WithError(err).Error("Failed to setup stream session")
+		i2pLogger.WithError(err).Error("Failed to setup stream session")
 		return nil, fmt.Errorf("onramp Listen: %v", err)
 	}
 	if g.StreamListener == nil {
-		i2plog.Debug("Creating new stream listener")
+		i2pLogger.Debug("Creating new stream listener")
 		g.StreamListener, err = g.StreamSession.Listen()
 		if err != nil {
-			i2plog.WithError(err).Error("Failed to create stream listener")
+			i2pLogger.WithError(err).Error("Failed to create stream listener")
 			return nil, fmt.Errorf("onramp Listen: %v", err)
 		}
-		i2plog.Debug("Stream listener created successfully")
+		i2pLogger.Debug("Stream listener created successfully")
 	}
 	return g.StreamListener, nil
 }
 
 // ListenPacket returns a net.PacketConn for the Garlic structure's I2P keys.
 func (g *Garlic) ListenPacket() (net.PacketConn, error) {
-	i2plog.Debug("Setting up packet connection")
+	i2pLogger.Debug("Setting up packet connection")
 	var err error
 	if g.SAM, err = g.samSession(); err != nil {
-		i2plog.WithError(err).Error("Failed to create SAM session for packet connection")
+		i2pLogger.WithError(err).Error("Failed to create SAM session for packet connection")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 	if g.DatagramSession, err = g.setupDatagramSession(); err != nil {
-		i2plog.WithError(err).Error("Failed to setup datagram session")
+		i2pLogger.WithError(err).Error("Failed to setup datagram session")
 		return nil, fmt.Errorf("onramp Listen: %v", err)
 	}
-	i2plog.Debug("Packet connection successfully established")
+	i2pLogger.Debug("Packet connection successfully established")
 	return g.DatagramSession, nil
 }
 
@@ -269,24 +269,24 @@ func (g *Garlic) ListenPacket() (net.PacketConn, error) {
 // which also uses TLS either for additional encryption, authentication,
 // or browser-compatibility.
 func (g *Garlic) ListenTLS(args ...string) (net.Listener, error) {
-	i2plog.WithField("args", args).Debug("Starting TLS listener")
+	i2pLogger.WithField("args", args).Debug("Starting TLS listener")
 	listener, err := g.Listen(args...)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to create base listener")
+		i2pLogger.WithError(err).Error("Failed to create base listener")
 		return nil, err
 	}
 	cert, err := g.TLSKeys()
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to get TLS keys")
+		i2pLogger.WithError(err).Error("Failed to get TLS keys")
 		return nil, fmt.Errorf("onramp ListenTLS: %v", err)
 	}
 	if len(args) > 0 {
 		protocol := args[0]
-		i2plog.WithField("protocol", protocol).Debug("Creating TLS listener for protocol")
+		i2pLogger.WithField("protocol", protocol).Debug("Creating TLS listener for protocol")
 
 		// if args[0] == "tcp" || args[0] == "tcp6" || args[0] == "st" || args[0] == "st6" {
 		if protocol == "tcp" || protocol == "tcp6" || protocol == "st" || protocol == "st6" {
-			i2plog.Debug("Creating TLS stream listener")
+			i2pLogger.Debug("Creating TLS stream listener")
 			return tls.NewListener(
 				g.StreamListener,
 				&tls.Config{
@@ -295,7 +295,7 @@ func (g *Garlic) ListenTLS(args ...string) (net.Listener, error) {
 			), nil
 			//} else if args[0] == "udp" || args[0] == "udp6" || args[0] == "dg" || args[0] == "dg6" {
 		} else if protocol == "udp" || protocol == "udp6" || protocol == "dg" || protocol == "dg6" {
-			i2plog.Debug("Creating TLS datagram listener")
+			i2pLogger.Debug("Creating TLS datagram listener")
 			return tls.NewListener(
 				g.DatagramSession,
 				&tls.Config{
@@ -305,10 +305,10 @@ func (g *Garlic) ListenTLS(args ...string) (net.Listener, error) {
 		}
 
 	} else {
-		i2plog.Debug("No protocol specified, using stream listener")
+		i2pLogger.Debug("No protocol specified, using stream listener")
 		g.StreamListener = listener.(*sam3.StreamListener)
 	}
-	i2plog.Debug("Successfully created TLS listener")
+	i2pLogger.Debug("Successfully created TLS listener")
 	return tls.NewListener(
 		g.StreamListener,
 		&tls.Config{
@@ -319,86 +319,86 @@ func (g *Garlic) ListenTLS(args ...string) (net.Listener, error) {
 
 // Dial returns a net.Conn for the Garlic structure's I2P keys.
 func (g *Garlic) Dial(net, addr string) (net.Conn, error) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"network": net,
 		"address": addr,
 	}).Debug("Attempting to dial")
 	if !strings.Contains(addr, ".i2p") {
-		i2plog.Debug("Non-I2P address detected, returning null connection")
+		i2pLogger.Debug("Non-I2P address detected, returning null connection")
 		return &NullConn{}, nil
 	}
 	var err error
 	if g.SAM, err = g.samSession(); err != nil {
-		i2plog.WithError(err).Error("Failed to create SAM session")
+		i2pLogger.WithError(err).Error("Failed to create SAM session")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 	if g.StreamSession, err = g.setupStreamSession(); err != nil {
-		i2plog.WithError(err).Error("Failed to setup stream session")
+		i2pLogger.WithError(err).Error("Failed to setup stream session")
 		return nil, fmt.Errorf("onramp Dial: %v", err)
 	}
-	i2plog.Debug("Attempting to establish connection")
+	i2pLogger.Debug("Attempting to establish connection")
 	conn, err := g.StreamSession.Dial(net, addr)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to establish connection")
+		i2pLogger.WithError(err).Error("Failed to establish connection")
 		return nil, err
 	}
-	i2plog.Debug("Successfully established connection")
+	i2pLogger.Debug("Successfully established connection")
 	return conn, nil
 	// return g.StreamSession.Dial(net, addr)
 }
 
 // DialContext returns a net.Conn for the Garlic structure's I2P keys.
 func (g *Garlic) DialContext(ctx context.Context, net, addr string) (net.Conn, error) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"network": net,
 		"address": addr,
 	}).Debug("Attempting to dial with context")
 	if !strings.Contains(addr, ".i2p") {
-		i2plog.Debug("Non-I2P address detected, returning null connection")
+		i2pLogger.Debug("Non-I2P address detected, returning null connection")
 		return &NullConn{}, nil
 	}
 	var err error
 	if g.SAM, err = g.samSession(); err != nil {
-		i2plog.WithError(err).Error("Failed to create SAM session")
+		i2pLogger.WithError(err).Error("Failed to create SAM session")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 	if g.StreamSession, err = g.setupStreamSession(); err != nil {
-		i2plog.WithError(err).Error("Failed to setup stream session")
+		i2pLogger.WithError(err).Error("Failed to setup stream session")
 		return nil, fmt.Errorf("onramp Dial: %v", err)
 	}
-	i2plog.Debug("Attempting to establish connection with context")
+	i2pLogger.Debug("Attempting to establish connection with context")
 	conn, err := g.StreamSession.DialContext(ctx, net, addr)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to establish connection")
+		i2pLogger.WithError(err).Error("Failed to establish connection")
 		return nil, err
 	}
 
-	i2plog.Debug("Successfully established connection")
+	i2pLogger.Debug("Successfully established connection")
 	return conn, nil
 	// return g.StreamSession.DialContext(ctx, net, addr)
 }
 
 // Close closes the Garlic structure's sessions and listeners.
 func (g *Garlic) Close() error {
-	i2plog.WithField("name", g.getName()).Debug("Closing Garlic sessions")
+	i2pLogger.WithField("name", g.getName()).Debug("Closing Garlic sessions")
 	e1 := g.StreamSession.Close()
 	var err error
 	if e1 != nil {
-		i2plog.WithError(e1).Error("Failed to close stream session")
+		i2pLogger.WithError(e1).Error("Failed to close stream session")
 		err = fmt.Errorf("onramp Close: %v", e1)
 	} else {
-		i2plog.Debug("Stream session closed successfully")
+		i2pLogger.Debug("Stream session closed successfully")
 	}
 	e2 := g.SAM.Close()
 	if e2 != nil {
-		i2plog.WithError(e2).Error("Failed to close SAM session")
+		i2pLogger.WithError(e2).Error("Failed to close SAM session")
 		err = fmt.Errorf("onramp Close: %v %v", e1, e2)
 	} else {
-		i2plog.Debug("SAM session closed successfully")
+		i2pLogger.Debug("SAM session closed successfully")
 	}
 
 	if err == nil {
-		i2plog.Debug("All sessions closed successfully")
+		i2pLogger.Debug("All sessions closed successfully")
 	}
 
 	return err
@@ -407,35 +407,35 @@ func (g *Garlic) Close() error {
 // Keys returns the I2PKeys for the Garlic structure. If none
 // exist, they are created and stored.
 func (g *Garlic) Keys() (*i2pkeys.I2PKeys, error) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"name":    g.getName(),
 		"address": g.getAddr(),
 	}).Debug("Retrieving I2P keys")
 
 	keys, err := I2PKeys(g.getName(), g.getAddr())
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to get I2P keys")
+		i2pLogger.WithError(err).Error("Failed to get I2P keys")
 		return &i2pkeys.I2PKeys{}, fmt.Errorf("onramp Keys: %v", err)
 	}
-	i2plog.Debug("Successfully retrieved I2P keys")
+	i2pLogger.Debug("Successfully retrieved I2P keys")
 	return &keys, nil
 }
 
 func (g *Garlic) DeleteKeys() error {
 	// return DeleteGarlicKeys(g.getName())
-	i2plog.WithField("name", g.getName()).Debug("Attempting to delete Garlic keys")
+	i2pLogger.WithField("name", g.getName()).Debug("Attempting to delete Garlic keys")
 	err := DeleteGarlicKeys(g.getName())
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to delete Garlic keys")
+		i2pLogger.WithError(err).Error("Failed to delete Garlic keys")
 	}
-	i2plog.Debug("Successfully deleted Garlic keys")
+	i2pLogger.Debug("Successfully deleted Garlic keys")
 	return err
 }
 
 // NewGarlic returns a new Garlic struct. It is immediately ready to use with
 // I2P streaming.
 func NewGarlic(tunName, samAddr string, options []string) (*Garlic, error) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"tunnel_name": tunName,
 		"sam_address": samAddr,
 		"options":     options,
@@ -447,15 +447,15 @@ func NewGarlic(tunName, samAddr string, options []string) (*Garlic, error) {
 	g.opts = options
 	var err error
 	if g.SAM, err = g.samSession(); err != nil {
-		i2plog.WithError(err).Error("Failed to create SAM session")
+		i2pLogger.WithError(err).Error("Failed to create SAM session")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 	if g.StreamSession, err = g.setupStreamSession(); err != nil {
-		i2plog.WithError(err).Error("Failed to setup stream session")
+		i2pLogger.WithError(err).Error("Failed to setup stream session")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 
-	i2plog.Debug("Successfully created new Garlic instance")
+	i2pLogger.Debug("Successfully created new Garlic instance")
 	return g, nil
 }
 
@@ -464,74 +464,74 @@ func NewGarlic(tunName, samAddr string, options []string) (*Garlic, error) {
 // This is permanent and irreversible, and will change the onion service
 // address.
 func DeleteGarlicKeys(tunName string) error {
-	i2plog.WithField("tunnel_name", tunName).Debug("Attempting to delete Garlic keys")
+	i2pLogger.WithField("tunnel_name", tunName).Debug("Attempting to delete Garlic keys")
 	keystore, err := I2PKeystorePath()
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to get keystore path")
+		i2pLogger.WithError(err).Error("Failed to get keystore path")
 		return fmt.Errorf("onramp DeleteGarlicKeys: discovery error %v", err)
 	}
 	keyspath := filepath.Join(keystore, tunName+".i2p.private")
-	i2plog.WithField("path", keyspath).Debug("Deleting key file")
+	i2pLogger.WithField("path", keyspath).Debug("Deleting key file")
 	if err := os.Remove(keyspath); err != nil {
-		i2plog.WithError(err).WithField("path", keyspath).Error("Failed to delete key file")
+		i2pLogger.WithError(err).WithField("path", keyspath).Error("Failed to delete key file")
 		return fmt.Errorf("onramp DeleteGarlicKeys: %v", err)
 	}
-	i2plog.Debug("Successfully deleted Garlic keys")
+	i2pLogger.Debug("Successfully deleted Garlic keys")
 	return nil
 }
 
 // I2PKeys returns the I2PKeys at the keystore directory for the given
 // tunnel name. If none exist, they are created and stored.
 func I2PKeys(tunName, samAddr string) (i2pkeys.I2PKeys, error) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"tunnel_name": tunName,
 		"sam_address": samAddr,
 	}).Debug("Looking up I2P keys")
 
 	keystore, err := I2PKeystorePath()
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to get keystore path")
+		i2pLogger.WithError(err).Error("Failed to get keystore path")
 		return i2pkeys.I2PKeys{}, fmt.Errorf("onramp I2PKeys: discovery error %v", err)
 	}
 	keyspath := filepath.Join(keystore, tunName+".i2p.private")
-	i2plog.WithField("path", keyspath).Debug("Checking for existing keys")
+	i2pLogger.WithField("path", keyspath).Debug("Checking for existing keys")
 	info, err := os.Stat(keyspath)
 	if info != nil {
 		if info.Size() == 0 {
-			i2plog.WithField("path", keyspath).Debug("Keystore empty, will regenerate keys")
-			i2plog.Println("onramp I2PKeys: keystore empty, re-generating keys")
+			i2pLogger.WithField("path", keyspath).Debug("Keystore empty, will regenerate keys")
+			i2pLogger.Println("onramp I2PKeys: keystore empty, re-generating keys")
 		} else {
-			i2plog.WithField("path", keyspath).Debug("Found existing keystore")
+			i2pLogger.WithField("path", keyspath).Debug("Found existing keystore")
 		}
 	}
 	if err != nil {
-		i2plog.WithField("path", keyspath).Debug("Keys not found, generating new keys")
+		i2pLogger.WithField("path", keyspath).Debug("Keys not found, generating new keys")
 		sam, err := sam3.NewSAM(samAddr)
 		if err != nil {
-			i2plog.WithError(err).Error("Failed to create SAM connection")
+			i2pLogger.WithError(err).Error("Failed to create SAM connection")
 			return i2pkeys.I2PKeys{}, fmt.Errorf("onramp I2PKeys: SAM error %v", err)
 		}
-		i2plog.Debug("SAM connection established")
+		i2pLogger.Debug("SAM connection established")
 		keys, err := sam.NewKeys(tunName)
 		if err != nil {
-			i2plog.WithError(err).Error("Failed to generate new keys")
+			i2pLogger.WithError(err).Error("Failed to generate new keys")
 			return i2pkeys.I2PKeys{}, fmt.Errorf("onramp I2PKeys: keygen error %v", err)
 		}
-		i2plog.Debug("New keys generated successfully")
+		i2pLogger.Debug("New keys generated successfully")
 		if err = i2pkeys.StoreKeys(keys, keyspath); err != nil {
-			i2plog.WithError(err).WithField("path", keyspath).Error("Failed to store generated keys")
+			i2pLogger.WithError(err).WithField("path", keyspath).Error("Failed to store generated keys")
 			return i2pkeys.I2PKeys{}, fmt.Errorf("onramp I2PKeys: store error %v", err)
 		}
-		i2plog.WithField("path", keyspath).Debug("Successfully stored new keys")
+		i2pLogger.WithField("path", keyspath).Debug("Successfully stored new keys")
 		return keys, nil
 	} else {
-		i2plog.WithField("path", keyspath).Debug("Loading existing keys")
+		i2pLogger.WithField("path", keyspath).Debug("Loading existing keys")
 		keys, err := i2pkeys.LoadKeys(keyspath)
 		if err != nil {
-			i2plog.WithError(err).WithField("path", keyspath).Error("Failed to load existing keys")
+			i2pLogger.WithError(err).WithField("path", keyspath).Error("Failed to load existing keys")
 			return i2pkeys.I2PKeys{}, fmt.Errorf("onramp I2PKeys: load error %v", err)
 		}
-		i2plog.Debug("Successfully loaded existing keys")
+		i2pLogger.Debug("Successfully loaded existing keys")
 		return keys, nil
 	}
 }
@@ -541,35 +541,35 @@ var garlics map[string]*Garlic
 // CloseAllGarlic closes all garlics managed by the onramp package. It does not
 // affect objects instantiated by an app.
 func CloseAllGarlic() {
-	i2plog.WithField("count", len(garlics)).Debug("Closing all Garlic connections")
+	i2pLogger.WithField("count", len(garlics)).Debug("Closing all Garlic connections")
 	for i, g := range garlics {
-		i2plog.WithFields(logrus.Fields{
+		i2pLogger.WithFields(logrus.Fields{
 			"index": i,
 			"name":  g.name,
 		}).Debug("Closing Garlic connection")
 
-		i2plog.Println("Closing garlic", g.name)
+		i2pLogger.Println("Closing garlic", g.name)
 		CloseGarlic(i)
 	}
-	i2plog.Debug("All Garlic connections closed")
+	i2pLogger.Debug("All Garlic connections closed")
 }
 
 // CloseGarlic closes the Garlic at the given index. It does not affect Garlic
 // objects instantiated by an app.
 func CloseGarlic(tunName string) {
-	i2plog.WithField("tunnel_name", tunName).Debug("Attempting to close Garlic connection")
+	i2pLogger.WithField("tunnel_name", tunName).Debug("Attempting to close Garlic connection")
 	g, ok := garlics[tunName]
 	if ok {
-		i2plog.Debug("Found Garlic connection, closing")
+		i2pLogger.Debug("Found Garlic connection, closing")
 		// g.Close()
 		err := g.Close()
 		if err != nil {
-			i2plog.WithError(err).Error("Error closing Garlic connection")
+			i2pLogger.WithError(err).Error("Error closing Garlic connection")
 		} else {
-			i2plog.Debug("Successfully closed Garlic connection")
+			i2pLogger.Debug("Successfully closed Garlic connection")
 		}
 	} else {
-		i2plog.Debug("No Garlic connection found for tunnel name")
+		i2pLogger.Debug("No Garlic connection found for tunnel name")
 	}
 }
 
@@ -581,18 +581,18 @@ var SAM_ADDR = "127.0.0.1:7656"
 // corresponding to a structure managed by the onramp library
 // and not instantiated by an app.
 func ListenGarlic(network, keys string) (net.Listener, error) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"network":  network,
 		"keys":     keys,
 		"sam_addr": SAM_ADDR,
 	}).Debug("Creating new Garlic listener")
 	g, err := NewGarlic(keys, SAM_ADDR, OPT_DEFAULTS)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to create new Garlic")
+		i2pLogger.WithError(err).Error("Failed to create new Garlic")
 		return nil, fmt.Errorf("onramp Listen: %v", err)
 	}
 	garlics[keys] = g
-	i2plog.Debug("Successfully created Garlic listener")
+	i2pLogger.Debug("Successfully created Garlic listener")
 	return g.Listen()
 }
 
@@ -600,7 +600,7 @@ func ListenGarlic(network, keys string) (net.Listener, error) {
 // corresponding to a structure managed by the onramp library
 // and not instantiated by an app.
 func DialGarlic(network, addr string) (net.Conn, error) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"network":  network,
 		"address":  addr,
 		"sam_addr": SAM_ADDR,
@@ -608,18 +608,18 @@ func DialGarlic(network, addr string) (net.Conn, error) {
 
 	g, err := NewGarlic(addr, SAM_ADDR, OPT_DEFAULTS)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to create new Garlic")
+		i2pLogger.WithError(err).Error("Failed to create new Garlic")
 		return nil, fmt.Errorf("onramp Dial: %v", err)
 	}
 	garlics[addr] = g
-	i2plog.WithField("address", addr).Debug("Attempting to dial")
+	i2pLogger.WithField("address", addr).Debug("Attempting to dial")
 	conn, err := g.Dial(network, addr)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to dial connection")
+		i2pLogger.WithError(err).Error("Failed to dial connection")
 		return nil, err
 	}
 
-	i2plog.Debug("Successfully established Garlic connection")
+	i2pLogger.Debug("Successfully established Garlic connection")
 	return conn, nil
 	// return g.Dial(network, addr)
 }

--- a/garlic.go
+++ b/garlic.go
@@ -12,10 +12,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/go-i2p/i2pkeys"
 	"github.com/go-i2p/sam3"
+	"github.com/sirupsen/logrus"
 )
 
 // Garlic is a ready-made I2P streaming manager. Once initialized it always
@@ -102,35 +101,35 @@ func (g *Garlic) getOptions() []string {
 
 func (g *Garlic) samSession() (*sam3.SAM, error) {
 	if g.SAM == nil {
-		log.WithField("address", g.getAddr()).Debug("Creating new SAM session")
+		i2plog.WithField("address", g.getAddr()).Debug("Creating new SAM session")
 		var err error
 		g.SAM, err = sam3.NewSAM(g.getAddr())
 		if err != nil {
-			log.WithError(err).Error("Failed to create SAM session")
+			i2plog.WithError(err).Error("Failed to create SAM session")
 			return nil, fmt.Errorf("onramp samSession: %v", err)
 		}
-		log.Debug("SAM session created successfully")
+		i2plog.Debug("SAM session created successfully")
 	}
 	return g.SAM, nil
 }
 
 func (g *Garlic) setupStreamSession() (*sam3.StreamSession, error) {
 	if g.StreamSession == nil {
-		log.WithField("name", g.getName()).Debug("Setting up stream session")
+		i2plog.WithField("name", g.getName()).Debug("Setting up stream session")
 		var err error
 		g.ServiceKeys, err = g.Keys()
 		if err != nil {
-			log.WithError(err).Error("Failed to get keys for stream session")
+			i2plog.WithError(err).Error("Failed to get keys for stream session")
 			return nil, fmt.Errorf("onramp setupStreamSession: %v", err)
 		}
-		log.WithField("address", g.ServiceKeys.Address.Base32()).Debug("Creating stream session with keys")
-		log.Println("Creating stream session with keys:", g.ServiceKeys.Address.Base32())
+		i2plog.WithField("address", g.ServiceKeys.Address.Base32()).Debug("Creating stream session with keys")
+		i2plog.Println("Creating stream session with keys:", g.ServiceKeys.Address.Base32())
 		g.StreamSession, err = g.SAM.NewStreamSession(g.getName(), *g.ServiceKeys, g.getOptions())
 		if err != nil {
-			log.WithError(err).Error("Failed to create stream session")
+			i2plog.WithError(err).Error("Failed to create stream session")
 			return nil, fmt.Errorf("onramp setupStreamSession: %v", err)
 		}
-		log.Debug("Stream session created successfully")
+		i2plog.Debug("Stream session created successfully")
 		return g.StreamSession, nil
 	}
 	return g.StreamSession, nil
@@ -138,43 +137,43 @@ func (g *Garlic) setupStreamSession() (*sam3.StreamSession, error) {
 
 func (g *Garlic) setupDatagramSession() (*sam3.DatagramSession, error) {
 	if g.DatagramSession == nil {
-		log.WithField("name", g.getName()).Debug("Setting up datagram session")
+		i2plog.WithField("name", g.getName()).Debug("Setting up datagram session")
 		var err error
 		g.ServiceKeys, err = g.Keys()
 		if err != nil {
-			log.WithError(err).Error("Failed to get keys for datagram session")
+			i2plog.WithError(err).Error("Failed to get keys for datagram session")
 			return nil, fmt.Errorf("onramp setupDatagramSession: %v", err)
 		}
-		log.WithField("address", g.ServiceKeys.Address.Base32()).Debug("Creating datagram session with keys")
-		log.Println("Creating datagram session with keys:", g.ServiceKeys.Address.Base32())
+		i2plog.WithField("address", g.ServiceKeys.Address.Base32()).Debug("Creating datagram session with keys")
+		i2plog.Println("Creating datagram session with keys:", g.ServiceKeys.Address.Base32())
 		g.DatagramSession, err = g.SAM.NewDatagramSession(g.getName(), *g.ServiceKeys, g.getOptions(), 0)
 		if err != nil {
-			log.WithError(err).Error("Failed to create datagram session")
+			i2plog.WithError(err).Error("Failed to create datagram session")
 			return nil, fmt.Errorf("onramp setupDatagramSession: %v", err)
 		}
-		log.Debug("Datagram session created successfully")
+		i2plog.Debug("Datagram session created successfully")
 		return g.DatagramSession, nil
 	}
 
-	log.Debug("Using existing datagram session")
+	i2plog.Debug("Using existing datagram session")
 	return g.DatagramSession, nil
 }
 
 // NewListener returns a net.Listener for the Garlic structure's I2P keys.
 // accepts a variable list of arguments, arguments after the first one are ignored.
 func (g *Garlic) NewListener(n, addr string) (net.Listener, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"network": n,
 		"address": addr,
 		"name":    g.getName(),
 	}).Debug("Creating new listener")
 	listener, err := g.Listen(n)
 	if err != nil {
-		log.WithError(err).Error("Failed to create listener")
+		i2plog.WithError(err).Error("Failed to create listener")
 		return nil, err
 	}
 
-	log.Debug("Successfully created listener")
+	i2plog.Debug("Successfully created listener")
 	return listener, nil
 	// return g.Listen(n)
 }
@@ -182,18 +181,18 @@ func (g *Garlic) NewListener(n, addr string) (net.Listener, error) {
 // Listen returns a net.Listener for the Garlic structure's I2P keys.
 // accepts a variable list of arguments, arguments after the first one are ignored.
 func (g *Garlic) Listen(args ...string) (net.Listener, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"args": args,
 		"name": g.getName(),
 	}).Debug("Setting up listener")
 
 	listener, err := g.OldListen(args...)
 	if err != nil {
-		log.WithError(err).Error("Failed to create listener")
+		i2plog.WithError(err).Error("Failed to create listener")
 		return nil, err
 	}
 
-	log.Debug("Successfully created listener")
+	i2plog.Debug("Successfully created listener")
 	return listener, nil
 	// return g.OldListen(args...)
 }
@@ -201,68 +200,68 @@ func (g *Garlic) Listen(args ...string) (net.Listener, error) {
 // OldListen returns a net.Listener for the Garlic structure's I2P keys.
 // accepts a variable list of arguments, arguments after the first one are ignored.
 func (g *Garlic) OldListen(args ...string) (net.Listener, error) {
-	log.WithField("args", args).Debug("Starting OldListen")
+	i2plog.WithField("args", args).Debug("Starting OldListen")
 	if len(args) > 0 {
 		protocol := args[0]
-		log.WithField("protocol", protocol).Debug("Checking protocol type")
+		i2plog.WithField("protocol", protocol).Debug("Checking protocol type")
 		// if args[0] == "tcp" || args[0] == "tcp6" || args[0] == "st" || args[0] == "st6" {
 		if protocol == "tcp" || protocol == "tcp6" || protocol == "st" || protocol == "st6" {
-			log.Debug("Using TCP stream listener")
+			i2plog.Debug("Using TCP stream listener")
 			return g.ListenStream()
 			//} else if args[0] == "udp" || args[0] == "udp6" || args[0] == "dg" || args[0] == "dg6" {
 		} else if protocol == "udp" || protocol == "udp6" || protocol == "dg" || protocol == "dg6" {
-			log.Debug("Using UDP datagram listener")
+			i2plog.Debug("Using UDP datagram listener")
 			pk, err := g.ListenPacket()
 			if err != nil {
-				log.WithError(err).Error("Failed to create packet listener")
+				i2plog.WithError(err).Error("Failed to create packet listener")
 				return nil, err
 			}
-			log.Debug("Successfully created datagram session")
+			i2plog.Debug("Successfully created datagram session")
 			return pk.(*sam3.DatagramSession), nil
 		}
 
 	}
-	log.Debug("No protocol specified, defaulting to stream listener")
+	i2plog.Debug("No protocol specified, defaulting to stream listener")
 	return g.ListenStream()
 }
 
 // Listen returns a net.Listener for the Garlic structure's I2P keys.
 func (g *Garlic) ListenStream() (net.Listener, error) {
-	log.Debug("Setting up stream listener")
+	i2plog.Debug("Setting up stream listener")
 	var err error
 	if g.SAM, err = g.samSession(); err != nil {
-		log.WithError(err).Error("Failed to create SAM session for stream listener")
+		i2plog.WithError(err).Error("Failed to create SAM session for stream listener")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 	if g.StreamSession, err = g.setupStreamSession(); err != nil {
-		log.WithError(err).Error("Failed to setup stream session")
+		i2plog.WithError(err).Error("Failed to setup stream session")
 		return nil, fmt.Errorf("onramp Listen: %v", err)
 	}
 	if g.StreamListener == nil {
-		log.Debug("Creating new stream listener")
+		i2plog.Debug("Creating new stream listener")
 		g.StreamListener, err = g.StreamSession.Listen()
 		if err != nil {
-			log.WithError(err).Error("Failed to create stream listener")
+			i2plog.WithError(err).Error("Failed to create stream listener")
 			return nil, fmt.Errorf("onramp Listen: %v", err)
 		}
-		log.Debug("Stream listener created successfully")
+		i2plog.Debug("Stream listener created successfully")
 	}
 	return g.StreamListener, nil
 }
 
 // ListenPacket returns a net.PacketConn for the Garlic structure's I2P keys.
 func (g *Garlic) ListenPacket() (net.PacketConn, error) {
-	log.Debug("Setting up packet connection")
+	i2plog.Debug("Setting up packet connection")
 	var err error
 	if g.SAM, err = g.samSession(); err != nil {
-		log.WithError(err).Error("Failed to create SAM session for packet connection")
+		i2plog.WithError(err).Error("Failed to create SAM session for packet connection")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 	if g.DatagramSession, err = g.setupDatagramSession(); err != nil {
-		log.WithError(err).Error("Failed to setup datagram session")
+		i2plog.WithError(err).Error("Failed to setup datagram session")
 		return nil, fmt.Errorf("onramp Listen: %v", err)
 	}
-	log.Debug("Packet connection successfully established")
+	i2plog.Debug("Packet connection successfully established")
 	return g.DatagramSession, nil
 }
 
@@ -270,24 +269,24 @@ func (g *Garlic) ListenPacket() (net.PacketConn, error) {
 // which also uses TLS either for additional encryption, authentication,
 // or browser-compatibility.
 func (g *Garlic) ListenTLS(args ...string) (net.Listener, error) {
-	log.WithField("args", args).Debug("Starting TLS listener")
+	i2plog.WithField("args", args).Debug("Starting TLS listener")
 	listener, err := g.Listen(args...)
 	if err != nil {
-		log.WithError(err).Error("Failed to create base listener")
+		i2plog.WithError(err).Error("Failed to create base listener")
 		return nil, err
 	}
 	cert, err := g.TLSKeys()
 	if err != nil {
-		log.WithError(err).Error("Failed to get TLS keys")
+		i2plog.WithError(err).Error("Failed to get TLS keys")
 		return nil, fmt.Errorf("onramp ListenTLS: %v", err)
 	}
 	if len(args) > 0 {
 		protocol := args[0]
-		log.WithField("protocol", protocol).Debug("Creating TLS listener for protocol")
+		i2plog.WithField("protocol", protocol).Debug("Creating TLS listener for protocol")
 
 		// if args[0] == "tcp" || args[0] == "tcp6" || args[0] == "st" || args[0] == "st6" {
 		if protocol == "tcp" || protocol == "tcp6" || protocol == "st" || protocol == "st6" {
-			log.Debug("Creating TLS stream listener")
+			i2plog.Debug("Creating TLS stream listener")
 			return tls.NewListener(
 				g.StreamListener,
 				&tls.Config{
@@ -296,7 +295,7 @@ func (g *Garlic) ListenTLS(args ...string) (net.Listener, error) {
 			), nil
 			//} else if args[0] == "udp" || args[0] == "udp6" || args[0] == "dg" || args[0] == "dg6" {
 		} else if protocol == "udp" || protocol == "udp6" || protocol == "dg" || protocol == "dg6" {
-			log.Debug("Creating TLS datagram listener")
+			i2plog.Debug("Creating TLS datagram listener")
 			return tls.NewListener(
 				g.DatagramSession,
 				&tls.Config{
@@ -306,10 +305,10 @@ func (g *Garlic) ListenTLS(args ...string) (net.Listener, error) {
 		}
 
 	} else {
-		log.Debug("No protocol specified, using stream listener")
+		i2plog.Debug("No protocol specified, using stream listener")
 		g.StreamListener = listener.(*sam3.StreamListener)
 	}
-	log.Debug("Successfully created TLS listener")
+	i2plog.Debug("Successfully created TLS listener")
 	return tls.NewListener(
 		g.StreamListener,
 		&tls.Config{
@@ -320,86 +319,86 @@ func (g *Garlic) ListenTLS(args ...string) (net.Listener, error) {
 
 // Dial returns a net.Conn for the Garlic structure's I2P keys.
 func (g *Garlic) Dial(net, addr string) (net.Conn, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"network": net,
 		"address": addr,
 	}).Debug("Attempting to dial")
 	if !strings.Contains(addr, ".i2p") {
-		log.Debug("Non-I2P address detected, returning null connection")
+		i2plog.Debug("Non-I2P address detected, returning null connection")
 		return &NullConn{}, nil
 	}
 	var err error
 	if g.SAM, err = g.samSession(); err != nil {
-		log.WithError(err).Error("Failed to create SAM session")
+		i2plog.WithError(err).Error("Failed to create SAM session")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 	if g.StreamSession, err = g.setupStreamSession(); err != nil {
-		log.WithError(err).Error("Failed to setup stream session")
+		i2plog.WithError(err).Error("Failed to setup stream session")
 		return nil, fmt.Errorf("onramp Dial: %v", err)
 	}
-	log.Debug("Attempting to establish connection")
+	i2plog.Debug("Attempting to establish connection")
 	conn, err := g.StreamSession.Dial(net, addr)
 	if err != nil {
-		log.WithError(err).Error("Failed to establish connection")
+		i2plog.WithError(err).Error("Failed to establish connection")
 		return nil, err
 	}
-	log.Debug("Successfully established connection")
+	i2plog.Debug("Successfully established connection")
 	return conn, nil
 	// return g.StreamSession.Dial(net, addr)
 }
 
 // DialContext returns a net.Conn for the Garlic structure's I2P keys.
 func (g *Garlic) DialContext(ctx context.Context, net, addr string) (net.Conn, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"network": net,
 		"address": addr,
 	}).Debug("Attempting to dial with context")
 	if !strings.Contains(addr, ".i2p") {
-		log.Debug("Non-I2P address detected, returning null connection")
+		i2plog.Debug("Non-I2P address detected, returning null connection")
 		return &NullConn{}, nil
 	}
 	var err error
 	if g.SAM, err = g.samSession(); err != nil {
-		log.WithError(err).Error("Failed to create SAM session")
+		i2plog.WithError(err).Error("Failed to create SAM session")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 	if g.StreamSession, err = g.setupStreamSession(); err != nil {
-		log.WithError(err).Error("Failed to setup stream session")
+		i2plog.WithError(err).Error("Failed to setup stream session")
 		return nil, fmt.Errorf("onramp Dial: %v", err)
 	}
-	log.Debug("Attempting to establish connection with context")
+	i2plog.Debug("Attempting to establish connection with context")
 	conn, err := g.StreamSession.DialContext(ctx, net, addr)
 	if err != nil {
-		log.WithError(err).Error("Failed to establish connection")
+		i2plog.WithError(err).Error("Failed to establish connection")
 		return nil, err
 	}
 
-	log.Debug("Successfully established connection")
+	i2plog.Debug("Successfully established connection")
 	return conn, nil
 	// return g.StreamSession.DialContext(ctx, net, addr)
 }
 
 // Close closes the Garlic structure's sessions and listeners.
 func (g *Garlic) Close() error {
-	log.WithField("name", g.getName()).Debug("Closing Garlic sessions")
+	i2plog.WithField("name", g.getName()).Debug("Closing Garlic sessions")
 	e1 := g.StreamSession.Close()
 	var err error
 	if e1 != nil {
-		log.WithError(e1).Error("Failed to close stream session")
+		i2plog.WithError(e1).Error("Failed to close stream session")
 		err = fmt.Errorf("onramp Close: %v", e1)
 	} else {
-		log.Debug("Stream session closed successfully")
+		i2plog.Debug("Stream session closed successfully")
 	}
 	e2 := g.SAM.Close()
 	if e2 != nil {
-		log.WithError(e2).Error("Failed to close SAM session")
+		i2plog.WithError(e2).Error("Failed to close SAM session")
 		err = fmt.Errorf("onramp Close: %v %v", e1, e2)
 	} else {
-		log.Debug("SAM session closed successfully")
+		i2plog.Debug("SAM session closed successfully")
 	}
 
 	if err == nil {
-		log.Debug("All sessions closed successfully")
+		i2plog.Debug("All sessions closed successfully")
 	}
 
 	return err
@@ -408,35 +407,35 @@ func (g *Garlic) Close() error {
 // Keys returns the I2PKeys for the Garlic structure. If none
 // exist, they are created and stored.
 func (g *Garlic) Keys() (*i2pkeys.I2PKeys, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"name":    g.getName(),
 		"address": g.getAddr(),
 	}).Debug("Retrieving I2P keys")
 
 	keys, err := I2PKeys(g.getName(), g.getAddr())
 	if err != nil {
-		log.WithError(err).Error("Failed to get I2P keys")
+		i2plog.WithError(err).Error("Failed to get I2P keys")
 		return &i2pkeys.I2PKeys{}, fmt.Errorf("onramp Keys: %v", err)
 	}
-	log.Debug("Successfully retrieved I2P keys")
+	i2plog.Debug("Successfully retrieved I2P keys")
 	return &keys, nil
 }
 
 func (g *Garlic) DeleteKeys() error {
 	// return DeleteGarlicKeys(g.getName())
-	log.WithField("name", g.getName()).Debug("Attempting to delete Garlic keys")
+	i2plog.WithField("name", g.getName()).Debug("Attempting to delete Garlic keys")
 	err := DeleteGarlicKeys(g.getName())
 	if err != nil {
-		log.WithError(err).Error("Failed to delete Garlic keys")
+		i2plog.WithError(err).Error("Failed to delete Garlic keys")
 	}
-	log.Debug("Successfully deleted Garlic keys")
+	i2plog.Debug("Successfully deleted Garlic keys")
 	return err
 }
 
 // NewGarlic returns a new Garlic struct. It is immediately ready to use with
 // I2P streaming.
 func NewGarlic(tunName, samAddr string, options []string) (*Garlic, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"tunnel_name": tunName,
 		"sam_address": samAddr,
 		"options":     options,
@@ -448,15 +447,15 @@ func NewGarlic(tunName, samAddr string, options []string) (*Garlic, error) {
 	g.opts = options
 	var err error
 	if g.SAM, err = g.samSession(); err != nil {
-		log.WithError(err).Error("Failed to create SAM session")
+		i2plog.WithError(err).Error("Failed to create SAM session")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 	if g.StreamSession, err = g.setupStreamSession(); err != nil {
-		log.WithError(err).Error("Failed to setup stream session")
+		i2plog.WithError(err).Error("Failed to setup stream session")
 		return nil, fmt.Errorf("onramp NewGarlic: %v", err)
 	}
 
-	log.Debug("Successfully created new Garlic instance")
+	i2plog.Debug("Successfully created new Garlic instance")
 	return g, nil
 }
 
@@ -465,74 +464,74 @@ func NewGarlic(tunName, samAddr string, options []string) (*Garlic, error) {
 // This is permanent and irreversible, and will change the onion service
 // address.
 func DeleteGarlicKeys(tunName string) error {
-	log.WithField("tunnel_name", tunName).Debug("Attempting to delete Garlic keys")
+	i2plog.WithField("tunnel_name", tunName).Debug("Attempting to delete Garlic keys")
 	keystore, err := I2PKeystorePath()
 	if err != nil {
-		log.WithError(err).Error("Failed to get keystore path")
+		i2plog.WithError(err).Error("Failed to get keystore path")
 		return fmt.Errorf("onramp DeleteGarlicKeys: discovery error %v", err)
 	}
 	keyspath := filepath.Join(keystore, tunName+".i2p.private")
-	log.WithField("path", keyspath).Debug("Deleting key file")
+	i2plog.WithField("path", keyspath).Debug("Deleting key file")
 	if err := os.Remove(keyspath); err != nil {
-		log.WithError(err).WithField("path", keyspath).Error("Failed to delete key file")
+		i2plog.WithError(err).WithField("path", keyspath).Error("Failed to delete key file")
 		return fmt.Errorf("onramp DeleteGarlicKeys: %v", err)
 	}
-	log.Debug("Successfully deleted Garlic keys")
+	i2plog.Debug("Successfully deleted Garlic keys")
 	return nil
 }
 
 // I2PKeys returns the I2PKeys at the keystore directory for the given
 // tunnel name. If none exist, they are created and stored.
 func I2PKeys(tunName, samAddr string) (i2pkeys.I2PKeys, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"tunnel_name": tunName,
 		"sam_address": samAddr,
 	}).Debug("Looking up I2P keys")
 
 	keystore, err := I2PKeystorePath()
 	if err != nil {
-		log.WithError(err).Error("Failed to get keystore path")
+		i2plog.WithError(err).Error("Failed to get keystore path")
 		return i2pkeys.I2PKeys{}, fmt.Errorf("onramp I2PKeys: discovery error %v", err)
 	}
 	keyspath := filepath.Join(keystore, tunName+".i2p.private")
-	log.WithField("path", keyspath).Debug("Checking for existing keys")
+	i2plog.WithField("path", keyspath).Debug("Checking for existing keys")
 	info, err := os.Stat(keyspath)
 	if info != nil {
 		if info.Size() == 0 {
-			log.WithField("path", keyspath).Debug("Keystore empty, will regenerate keys")
-			log.Println("onramp I2PKeys: keystore empty, re-generating keys")
+			i2plog.WithField("path", keyspath).Debug("Keystore empty, will regenerate keys")
+			i2plog.Println("onramp I2PKeys: keystore empty, re-generating keys")
 		} else {
-			log.WithField("path", keyspath).Debug("Found existing keystore")
+			i2plog.WithField("path", keyspath).Debug("Found existing keystore")
 		}
 	}
 	if err != nil {
-		log.WithField("path", keyspath).Debug("Keys not found, generating new keys")
+		i2plog.WithField("path", keyspath).Debug("Keys not found, generating new keys")
 		sam, err := sam3.NewSAM(samAddr)
 		if err != nil {
-			log.WithError(err).Error("Failed to create SAM connection")
+			i2plog.WithError(err).Error("Failed to create SAM connection")
 			return i2pkeys.I2PKeys{}, fmt.Errorf("onramp I2PKeys: SAM error %v", err)
 		}
-		log.Debug("SAM connection established")
+		i2plog.Debug("SAM connection established")
 		keys, err := sam.NewKeys(tunName)
 		if err != nil {
-			log.WithError(err).Error("Failed to generate new keys")
+			i2plog.WithError(err).Error("Failed to generate new keys")
 			return i2pkeys.I2PKeys{}, fmt.Errorf("onramp I2PKeys: keygen error %v", err)
 		}
-		log.Debug("New keys generated successfully")
+		i2plog.Debug("New keys generated successfully")
 		if err = i2pkeys.StoreKeys(keys, keyspath); err != nil {
-			log.WithError(err).WithField("path", keyspath).Error("Failed to store generated keys")
+			i2plog.WithError(err).WithField("path", keyspath).Error("Failed to store generated keys")
 			return i2pkeys.I2PKeys{}, fmt.Errorf("onramp I2PKeys: store error %v", err)
 		}
-		log.WithField("path", keyspath).Debug("Successfully stored new keys")
+		i2plog.WithField("path", keyspath).Debug("Successfully stored new keys")
 		return keys, nil
 	} else {
-		log.WithField("path", keyspath).Debug("Loading existing keys")
+		i2plog.WithField("path", keyspath).Debug("Loading existing keys")
 		keys, err := i2pkeys.LoadKeys(keyspath)
 		if err != nil {
-			log.WithError(err).WithField("path", keyspath).Error("Failed to load existing keys")
+			i2plog.WithError(err).WithField("path", keyspath).Error("Failed to load existing keys")
 			return i2pkeys.I2PKeys{}, fmt.Errorf("onramp I2PKeys: load error %v", err)
 		}
-		log.Debug("Successfully loaded existing keys")
+		i2plog.Debug("Successfully loaded existing keys")
 		return keys, nil
 	}
 }
@@ -542,35 +541,35 @@ var garlics map[string]*Garlic
 // CloseAllGarlic closes all garlics managed by the onramp package. It does not
 // affect objects instantiated by an app.
 func CloseAllGarlic() {
-	log.WithField("count", len(garlics)).Debug("Closing all Garlic connections")
+	i2plog.WithField("count", len(garlics)).Debug("Closing all Garlic connections")
 	for i, g := range garlics {
-		log.WithFields(logrus.Fields{
+		i2plog.WithFields(logrus.Fields{
 			"index": i,
 			"name":  g.name,
 		}).Debug("Closing Garlic connection")
 
-		log.Println("Closing garlic", g.name)
+		i2plog.Println("Closing garlic", g.name)
 		CloseGarlic(i)
 	}
-	log.Debug("All Garlic connections closed")
+	i2plog.Debug("All Garlic connections closed")
 }
 
 // CloseGarlic closes the Garlic at the given index. It does not affect Garlic
 // objects instantiated by an app.
 func CloseGarlic(tunName string) {
-	log.WithField("tunnel_name", tunName).Debug("Attempting to close Garlic connection")
+	i2plog.WithField("tunnel_name", tunName).Debug("Attempting to close Garlic connection")
 	g, ok := garlics[tunName]
 	if ok {
-		log.Debug("Found Garlic connection, closing")
+		i2plog.Debug("Found Garlic connection, closing")
 		// g.Close()
 		err := g.Close()
 		if err != nil {
-			log.WithError(err).Error("Error closing Garlic connection")
+			i2plog.WithError(err).Error("Error closing Garlic connection")
 		} else {
-			log.Debug("Successfully closed Garlic connection")
+			i2plog.Debug("Successfully closed Garlic connection")
 		}
 	} else {
-		log.Debug("No Garlic connection found for tunnel name")
+		i2plog.Debug("No Garlic connection found for tunnel name")
 	}
 }
 
@@ -582,18 +581,18 @@ var SAM_ADDR = "127.0.0.1:7656"
 // corresponding to a structure managed by the onramp library
 // and not instantiated by an app.
 func ListenGarlic(network, keys string) (net.Listener, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"network":  network,
 		"keys":     keys,
 		"sam_addr": SAM_ADDR,
 	}).Debug("Creating new Garlic listener")
 	g, err := NewGarlic(keys, SAM_ADDR, OPT_DEFAULTS)
 	if err != nil {
-		log.WithError(err).Error("Failed to create new Garlic")
+		i2plog.WithError(err).Error("Failed to create new Garlic")
 		return nil, fmt.Errorf("onramp Listen: %v", err)
 	}
 	garlics[keys] = g
-	log.Debug("Successfully created Garlic listener")
+	i2plog.Debug("Successfully created Garlic listener")
 	return g.Listen()
 }
 
@@ -601,7 +600,7 @@ func ListenGarlic(network, keys string) (net.Listener, error) {
 // corresponding to a structure managed by the onramp library
 // and not instantiated by an app.
 func DialGarlic(network, addr string) (net.Conn, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"network":  network,
 		"address":  addr,
 		"sam_addr": SAM_ADDR,
@@ -609,18 +608,18 @@ func DialGarlic(network, addr string) (net.Conn, error) {
 
 	g, err := NewGarlic(addr, SAM_ADDR, OPT_DEFAULTS)
 	if err != nil {
-		log.WithError(err).Error("Failed to create new Garlic")
+		i2plog.WithError(err).Error("Failed to create new Garlic")
 		return nil, fmt.Errorf("onramp Dial: %v", err)
 	}
 	garlics[addr] = g
-	log.WithField("address", addr).Debug("Attempting to dial")
+	i2plog.WithField("address", addr).Debug("Attempting to dial")
 	conn, err := g.Dial(network, addr)
 	if err != nil {
-		log.WithError(err).Error("Failed to dial connection")
+		i2plog.WithError(err).Error("Failed to dial connection")
 		return nil, err
 	}
 
-	log.Debug("Successfully established Garlic connection")
+	i2plog.Debug("Successfully established Garlic connection")
 	return conn, nil
 	// return g.Dial(network, addr)
 }

--- a/garlic_test.go
+++ b/garlic_test.go
@@ -6,7 +6,7 @@ package onramp
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"testing"
@@ -25,7 +25,7 @@ func TestBareGarlic(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	log.Println("listener:", listener.Addr().String())
+	i2plog.Println("listener:", listener.Addr().String())
 	defer listener.Close()
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello, %q", r.URL.Path)
@@ -52,7 +52,7 @@ func TestBareGarlic(t *testing.T) {
 	}
 	defer resp.Body.Close()
 	fmt.Println(resp.Status)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Error(err)
 	}
@@ -62,7 +62,7 @@ func TestBareGarlic(t *testing.T) {
 
 func Serve(listener net.Listener) {
 	if err := http.Serve(listener, nil); err != nil {
-		log.Fatal(err)
+		i2plog.Fatal(err)
 	}
 }
 
@@ -70,6 +70,6 @@ func Sleep(count int) {
 	for i := 0; i < count; i++ {
 		time.Sleep(time.Second)
 		x := count - i
-		log.Printf("Waiting: %d seconds\n", x)
+		i2plog.Printf("Waiting: %d seconds\n", x)
 	}
 }

--- a/garlic_test.go
+++ b/garlic_test.go
@@ -25,7 +25,7 @@ func TestBareGarlic(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	i2plog.Println("listener:", listener.Addr().String())
+	i2pLogger.Println("listener:", listener.Addr().String())
 	defer listener.Close()
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello, %q", r.URL.Path)
@@ -62,7 +62,7 @@ func TestBareGarlic(t *testing.T) {
 
 func Serve(listener net.Listener) {
 	if err := http.Serve(listener, nil); err != nil {
-		i2plog.Fatal(err)
+		i2pLogger.Fatal(err)
 	}
 }
 
@@ -70,6 +70,6 @@ func Sleep(count int) {
 	for i := 0; i < count; i++ {
 		time.Sleep(time.Second)
 		x := count - i
-		i2plog.Printf("Waiting: %d seconds\n", x)
+		i2pLogger.Printf("Waiting: %d seconds\n", x)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,13 @@
 module github.com/go-i2p/onramp
 
-go 1.18
+go 1.23.3
+
+toolchain go1.24.1
 
 require (
 	github.com/cretz/bine v0.2.0
 	github.com/go-i2p/i2pkeys v0.33.10-0.20241113193422-e10de5e60708
+	github.com/go-i2p/logger v0.0.0-20241123010126-3050657e5d0c
 	github.com/go-i2p/sam3 v0.33.9
 	github.com/sirupsen/logrus v1.9.3
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/go-i2p/i2pkeys v0.0.0-20241108200332-e4f5ccdff8c4/go.mod h1:m5TlHjPZrU5KbTd7Lr+I2rljyC6aJ88HdkeMQXV0U0E=
 github.com/go-i2p/i2pkeys v0.33.10-0.20241113193422-e10de5e60708 h1:Tiy9IBwi21maNpK74yCdHursJJMkyH7w87tX1nXGWzg=
 github.com/go-i2p/i2pkeys v0.33.10-0.20241113193422-e10de5e60708/go.mod h1:m5TlHjPZrU5KbTd7Lr+I2rljyC6aJ88HdkeMQXV0U0E=
+github.com/go-i2p/logger v0.0.0-20241123010126-3050657e5d0c h1:VTiECn3dFEmUlZjto+wOwJ7SSJTHPLyNprQMR5HzIMI=
+github.com/go-i2p/logger v0.0.0-20241123010126-3050657e5d0c/go.mod h1:te7Zj3g3oMeIl8uBXAgO62UKmZ6m6kHRNg1Mm+X8Hzk=
 github.com/go-i2p/sam3 v0.33.9 h1:3a+gunx75DFc6jxloUZTAVJbdP6736VU1dy2i7I9fKA=
 github.com/go-i2p/sam3 v0.33.9/go.mod h1:oDuV145l5XWKKafeE4igJHTDpPwA0Yloz9nyKKh92eo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -17,14 +19,10 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
-golang.org/x/crypto v0.11.0 h1:6Ewdq3tDic1mg5xRO4milcWCfMVQhI4NkqWWvqejpuA=
-golang.org/x/crypto v0.11.0/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
 golang.org/x/crypto v0.29.0 h1:L5SG1JTTXupVV3n6sUqMTeWbjAyfPwoda2DLX8J8FrQ=
 golang.org/x/crypto v0.29.0/go.mod h1:+F4F4N5hv6v38hfeYwTdx20oUvLLc+QfrE9Ax9HtgRg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.12.0 h1:cfawfvKITfUsFCeJIHJrbSxpeu/E81khclypR0GVT50=
-golang.org/x/net v0.12.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
 golang.org/x/net v0.31.0 h1:68CPQngjLL0r2AlUKiSxtQFKvzRVbnzLwMUn5SzcLHo=
 golang.org/x/net v0.31.0/go.mod h1:P4fl1q7dY2hnZFxEk4pPSkDHF+QqjitcnDjUQyMM+pM=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -39,3 +37,4 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/log.go
+++ b/log.go
@@ -5,9 +5,9 @@ import (
 )
 
 var (
-	i2plog *logger.Logger
+	i2pLogger *logger.Logger
 )
 
 func init() {
-	i2plog = logger.GetGoI2PLogger()
+	i2pLogger = logger.GetGoI2PLogger()
 }

--- a/log.go
+++ b/log.go
@@ -1,51 +1,13 @@
 package onramp
 
 import (
-	"io"
-	"os"
-	"strings"
-	"sync"
-
-	"github.com/sirupsen/logrus"
+	"github.com/go-i2p/logger"
 )
 
 var (
-	log  *logrus.Logger
-	once sync.Once
+	i2plog *logger.Logger
 )
 
-func InitializeOnrampLogger() {
-	once.Do(func() {
-		log = logrus.New()
-		// We do not want to log by default
-		log.SetOutput(io.Discard)
-		log.SetLevel(logrus.PanicLevel)
-		// Check if DEBUG_I2P is set
-		if logLevel := os.Getenv("DEBUG_I2P"); logLevel != "" {
-			log.SetOutput(os.Stdout)
-			switch strings.ToLower(logLevel) {
-			case "debug":
-				log.SetLevel(logrus.DebugLevel)
-			case "warn":
-				log.SetLevel(logrus.WarnLevel)
-			case "error":
-				log.SetLevel(logrus.ErrorLevel)
-			default:
-				log.SetLevel(logrus.DebugLevel)
-			}
-			log.WithField("level", log.GetLevel()).Debug("Logging enabled.")
-		}
-	})
-}
-
-// GetI2PKeysLogger returns the initialized logger
-func GetOnrampLogger() *logrus.Logger {
-	if log == nil {
-		InitializeOnrampLogger()
-	}
-	return log
-}
-
 func init() {
-	GetOnrampLogger()
+	i2plog = logger.GetGoI2PLogger()
 }

--- a/onion.go
+++ b/onion.go
@@ -47,7 +47,7 @@ func (o *Onion) getContext() context.Context {
 func (o *Onion) getListenConf() *tor.ListenConf {
 	keys, err := o.Keys()
 	if err != nil {
-		log.Fatalf("Unable to get onion service keys, %s", err)
+		i2plog.Fatalf("Unable to get onion service keys, %s", err)
 	}
 	if o.ListenConf == nil {
 		o.ListenConf = &tor.ListenConf{
@@ -66,14 +66,14 @@ func (o *Onion) getDialConf() *tor.DialConf {
 
 func (o *Onion) getTor() *tor.Tor {
 	if torp == nil {
-		log.Debug("Initializing new Tor instance")
+		i2plog.Debug("Initializing new Tor instance")
 		var err error
 		torp, err = tor.Start(o.getContext(), o.getStartConf())
 		if err != nil {
-			log.WithError(err).Error("Failed to start Tor")
+			i2plog.WithError(err).Error("Failed to start Tor")
 			panic(err) // return nil instead?
 		}
-		log.Debug("Tor instance started successfully")
+		i2plog.Debug("Tor instance started successfully")
 	}
 	return torp
 }
@@ -82,13 +82,13 @@ func (o *Onion) getDialer() *tor.Dialer {
 	// if o.Dialer == nil {
 	// var err error
 	// o.Dialer, err
-	log.Debug("Creating new Tor dialer")
+	i2plog.Debug("Creating new Tor dialer")
 	dialer, err := o.getTor().Dialer(o.getContext(), o.getDialConf())
 	if err != nil {
-		log.WithError(err).Error("Failed to create Tor dialer")
+		i2plog.WithError(err).Error("Failed to create Tor dialer")
 		panic(err)
 	}
-	log.Debug("Tor dialer created successfully")
+	i2plog.Debug("Tor dialer created successfully")
 	//}
 	//return o.Dialer
 	return dialer
@@ -112,17 +112,17 @@ func (o *Onion) NewListener(n, addr string) (net.Listener, error) {
 // address, and will automatically generate a keypair and store it.
 // the args are always ignored
 func (o *Onion) Listen(args ...string) (net.Listener, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"args": args,
 		"name": o.getName(),
 	}).Debug("Setting up Onion listener")
 	listener, err := o.OldListen(args...)
 	if err != nil {
-		log.WithError(err).Error("Failed to create Onion listener")
+		i2plog.WithError(err).Error("Failed to create Onion listener")
 		return nil, err
 	}
 
-	log.Debug("Successfully created Onion listener")
+	i2plog.Debug("Successfully created Onion listener")
 	return listener, nil
 	// return o.OldListen(args...)
 }
@@ -131,15 +131,15 @@ func (o *Onion) Listen(args ...string) (net.Listener, error) {
 // address, and will automatically generate a keypair and store it.
 // the args are always ignored
 func (o *Onion) OldListen(args ...string) (net.Listener, error) {
-	log.WithField("name", o.getName()).Debug("Creating Tor listener")
+	i2plog.WithField("name", o.getName()).Debug("Creating Tor listener")
 
 	listener, err := o.getTor().Listen(o.getContext(), o.getListenConf())
 	if err != nil {
-		log.WithError(err).Error("Failed to create Tor listener")
+		i2plog.WithError(err).Error("Failed to create Tor listener")
 		return nil, err
 	}
 
-	log.Debug("Successfully created Tor listener")
+	i2plog.Debug("Successfully created Tor listener")
 	return listener, nil
 	// return o.getTor().Listen(o.getContext(), o.getListenConf())
 }
@@ -148,19 +148,19 @@ func (o *Onion) OldListen(args ...string) (net.Listener, error) {
 // to the onion listener, which will not be decrypted until it reaches
 // the browser
 func (o *Onion) ListenTLS(args ...string) (net.Listener, error) {
-	log.WithField("args", args).Debug("Setting up TLS Onion listener")
+	i2plog.WithField("args", args).Debug("Setting up TLS Onion listener")
 	cert, err := o.TLSKeys()
 	if err != nil {
-		log.WithError(err).Error("Failed to get TLS keys")
+		i2plog.WithError(err).Error("Failed to get TLS keys")
 		return nil, fmt.Errorf("onramp ListenTLS: %v", err)
 	}
-	log.Debug("Creating base Tor listener")
+	i2plog.Debug("Creating base Tor listener")
 	l, err := o.getTor().Listen(o.getContext(), o.getListenConf())
 	if err != nil {
-		log.WithError(err).Error("Failed to create base Tor listener")
+		i2plog.WithError(err).Error("Failed to create base Tor listener")
 		return nil, err
 	}
-	log.Debug("Wrapping Tor listener with TLS")
+	i2plog.Debug("Wrapping Tor listener with TLS")
 	return tls.NewListener(
 		l,
 		&tls.Config{
@@ -171,47 +171,47 @@ func (o *Onion) ListenTLS(args ...string) (net.Listener, error) {
 
 // Dial returns a net.Conn to the given onion address or clearnet address.
 func (o *Onion) Dial(net, addr string) (net.Conn, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"network": net,
 		"address": addr,
 	}).Debug("Attempting to dial via Tor")
 	conn, err := o.getDialer().DialContext(o.getContext(), net, addr)
 	if err != nil {
-		log.WithError(err).Error("Failed to establish Tor connection")
+		i2plog.WithError(err).Error("Failed to establish Tor connection")
 		return nil, err
 	}
 
-	log.Debug("Successfully established Tor connection")
+	i2plog.Debug("Successfully established Tor connection")
 	return conn, nil
 	// return o.getDialer().DialContext(o.getContext(), net, addr)
 }
 
 // Close closes the Onion Service and all associated resources.
 func (o *Onion) Close() error {
-	log.WithField("name", o.getName()).Debug("Closing Onion service")
+	i2plog.WithField("name", o.getName()).Debug("Closing Onion service")
 
 	err := o.getTor().Close()
 	if err != nil {
-		log.WithError(err).Error("Failed to close Tor instance")
+		i2plog.WithError(err).Error("Failed to close Tor instance")
 		return err
 	}
 
-	log.Debug("Successfully closed Onion service")
+	i2plog.Debug("Successfully closed Onion service")
 	return nil
 	// return o.getTor().Close()
 }
 
 // Keys returns the keys for the Onion
 func (o *Onion) Keys() (ed25519.KeyPair, error) {
-	log.WithField("name", o.getName()).Debug("Retrieving Onion keys")
+	i2plog.WithField("name", o.getName()).Debug("Retrieving Onion keys")
 
 	keys, err := TorKeys(o.getName())
 	if err != nil {
-		log.WithError(err).Error("Failed to get Tor keys")
+		i2plog.WithError(err).Error("Failed to get Tor keys")
 		return nil, err
 	}
 
-	log.Debug("Successfully retrieved Onion keys")
+	i2plog.Debug("Successfully retrieved Onion keys")
 	return keys, nil
 	// return TorKeys(o.getName())
 }
@@ -220,7 +220,7 @@ func (o *Onion) Keys() (ed25519.KeyPair, error) {
 // This is permanent and irreversible, and will change the onion service
 // address.
 func (g *Onion) DeleteKeys() error {
-	log.WithField("Onion keys", g.getName()).Debug("Deleting Onion keys")
+	i2plog.WithField("Onion keys", g.getName()).Debug("Deleting Onion keys")
 	return DeleteOnionKeys(g.getName())
 }
 
@@ -235,50 +235,50 @@ func NewOnion(name string) (*Onion, error) {
 // name in the key store. If the key already exists, it will be
 // returned. If it does not exist, it will be generated.
 func TorKeys(keyName string) (ed25519.KeyPair, error) {
-	log.WithField("key_name", keyName).Debug("Getting Tor keys")
+	i2plog.WithField("key_name", keyName).Debug("Getting Tor keys")
 	keystore, err := TorKeystorePath()
 	if err != nil {
-		log.WithError(err).Error("Failed to get keystore path")
+		i2plog.WithError(err).Error("Failed to get keystore path")
 		return nil, fmt.Errorf("onramp OnionKeys: discovery error %v", err)
 	}
 	var keys ed25519.KeyPair
 	keysPath := filepath.Join(keystore, keyName+".tor.private")
-	log.WithField("path", keysPath).Debug("Checking for existing keys")
+	i2plog.WithField("path", keysPath).Debug("Checking for existing keys")
 	if _, err := os.Stat(keysPath); os.IsNotExist(err) {
-		log.Debug("Generating new Tor keys")
+		i2plog.Debug("Generating new Tor keys")
 		tkeys, err := ed25519.GenerateKey(nil)
 		if err != nil {
-			log.WithError(err).Error("Failed to generate onion service key")
-			log.Fatal("Unable to generate onion service key")
+			i2plog.WithError(err).Error("Failed to generate onion service key")
+			i2plog.Fatal("Unable to generate onion service key")
 		}
 		keys = tkeys
 
-		log.WithField("path", keysPath).Debug("Creating key file")
+		i2plog.WithField("path", keysPath).Debug("Creating key file")
 		f, err := os.Create(keysPath)
 		if err != nil {
-			log.WithError(err).Error("Failed to create Tor keys file")
-			log.Fatal("Unable to create Tor keys file for writing")
+			i2plog.WithError(err).Error("Failed to create Tor keys file")
+			i2plog.Fatal("Unable to create Tor keys file for writing")
 		}
 		defer f.Close()
 		_, err = f.Write(tkeys.PrivateKey())
 		if err != nil {
-			log.WithError(err).Error("Failed to write Tor keys to disk")
-			log.Fatal("Unable to write Tor keys to disk")
+			i2plog.WithError(err).Error("Failed to write Tor keys to disk")
+			i2plog.Fatal("Unable to write Tor keys to disk")
 		}
-		log.Debug("Successfully generated and stored new keys")
+		i2plog.Debug("Successfully generated and stored new keys")
 	} else if err == nil {
-		log.Debug("Loading existing Tor keys")
+		i2plog.Debug("Loading existing Tor keys")
 		tkeys, err := os.ReadFile(keysPath)
 		if err != nil {
-			log.WithError(err).Error("Failed to read Tor keys from disk")
-			log.Fatal("Unable to read Tor keys from disk")
+			i2plog.WithError(err).Error("Failed to read Tor keys from disk")
+			i2plog.Fatal("Unable to read Tor keys from disk")
 		}
 		k := ed25519.FromCryptoPrivateKey(tkeys)
 		keys = k
-		log.Debug("Successfully loaded existing keys")
+		i2plog.Debug("Successfully loaded existing keys")
 	} else {
-		log.WithError(err).Error("Failed to set up Tor keys")
-		log.Fatal("Unable to set up Tor keys")
+		i2plog.WithError(err).Error("Failed to set up Tor keys")
+		i2plog.Fatal("Unable to set up Tor keys")
 	}
 	return keys, nil
 }
@@ -288,34 +288,34 @@ var onions map[string]*Onion
 // CloseAllOnion closes all onions managed by the onramp package. It does not
 // affect objects instantiated by an app.
 func CloseAllOnion() {
-	log.WithField("count", len(onions)).Debug("Closing all Onion services")
+	i2plog.WithField("count", len(onions)).Debug("Closing all Onion services")
 	for i, g := range onions {
-		log.WithFields(logrus.Fields{
+		i2plog.WithFields(logrus.Fields{
 			"index": i,
 			"name":  g.name,
 		}).Debug("Closing Onion service")
 		CloseOnion(i)
 	}
 
-	log.Debug("All Onion services closed")
+	i2plog.Debug("All Onion services closed")
 }
 
 // CloseOnion closes the Onion at the given index. It does not affect Onion
 // objects instantiated by an app.
 func CloseOnion(tunName string) {
-	log.WithField("tunnel_name", tunName).Debug("Attempting to close Onion service")
+	i2plog.WithField("tunnel_name", tunName).Debug("Attempting to close Onion service")
 
 	g, ok := onions[tunName]
 	if ok {
-		log.WithField("name", g.name).Debug("Found Onion service, closing")
+		i2plog.WithField("name", g.name).Debug("Found Onion service, closing")
 		err := g.Close()
 		if err != nil {
-			log.WithError(err).Error("Failed to close Onion service")
+			i2plog.WithError(err).Error("Failed to close Onion service")
 		} else {
-			log.Debug("Successfully closed Onion service")
+			i2plog.Debug("Successfully closed Onion service")
 		}
 	} else {
-		log.Debug("No Onion service found for tunnel name")
+		i2plog.Debug("No Onion service found for tunnel name")
 	}
 }
 
@@ -323,26 +323,26 @@ func CloseOnion(tunName string) {
 // corresponding to a structure managed by the onramp library
 // and not instantiated by an app.
 func ListenOnion(network, keys string) (net.Listener, error) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"network": network,
 		"keys":    keys,
 	}).Debug("Creating new Onion listener")
 
 	g, err := NewOnion(keys)
 	if err != nil {
-		log.WithError(err).Error("Failed to create new Onion")
+		i2plog.WithError(err).Error("Failed to create new Onion")
 		return nil, fmt.Errorf("onramp Listen: %v", err)
 	}
 	onions[keys] = g
-	log.Debug("Onion service registered, creating listener")
+	i2plog.Debug("Onion service registered, creating listener")
 
 	listener, err := g.Listen()
 	if err != nil {
-		log.WithError(err).Error("Failed to create Onion listener")
+		i2plog.WithError(err).Error("Failed to create Onion listener")
 		return nil, err
 	}
 
-	log.Debug("Successfully created Onion listener")
+	i2plog.Debug("Successfully created Onion listener")
 	return listener, nil
 	// return g.Listen()
 }
@@ -362,19 +362,19 @@ func DialOnion(network, addr string) (net.Conn, error) {
 // DeleteOnionKeys deletes the key file at the given path as determined by
 // keystore + tunName.
 func DeleteOnionKeys(tunName string) error {
-	log.WithField("tunnel_name", tunName).Debug("Attempting to delete Onion keys")
+	i2plog.WithField("tunnel_name", tunName).Debug("Attempting to delete Onion keys")
 
 	keystore, err := TorKeystorePath()
 	if err != nil {
-		log.WithError(err).Error("Failed to get keystore path")
+		i2plog.WithError(err).Error("Failed to get keystore path")
 		return fmt.Errorf("onramp DeleteOnionKeys: discovery error %v", err)
 	}
 	keyspath := filepath.Join(keystore, tunName+".i2p.private")
-	log.WithError(err).Error("Failed to get keystore path")
+	i2plog.WithError(err).Error("Failed to get keystore path")
 	if err := os.Remove(keyspath); err != nil {
-		log.WithError(err).WithField("path", keyspath).Error("Failed to delete key file")
+		i2plog.WithError(err).WithField("path", keyspath).Error("Failed to delete key file")
 		return fmt.Errorf("onramp DeleteOnionKeys: %v", err)
 	}
-	log.Debug("Successfully deleted Onion keys")
+	i2plog.Debug("Successfully deleted Onion keys")
 	return nil
 }

--- a/onion_test.go
+++ b/onion_test.go
@@ -6,7 +6,7 @@ package onramp
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -23,7 +23,7 @@ func TestBareOnion(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	log.Println("listener:", listener.Addr().String())
+	i2plog.Println("listener:", listener.Addr().String())
 	// defer listener.Close()
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello, %q", r.URL.Path)
@@ -44,7 +44,7 @@ func TestBareOnion(t *testing.T) {
 		t.Error(err)
 	}
 	fmt.Println("Status:", resp.Status)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Error(err)
 	}

--- a/onion_test.go
+++ b/onion_test.go
@@ -23,7 +23,7 @@ func TestBareOnion(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	i2plog.Println("listener:", listener.Addr().String())
+	i2pLogger.Println("listener:", listener.Addr().String())
 	// defer listener.Close()
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello, %q", r.URL.Path)

--- a/proxy.go
+++ b/proxy.go
@@ -22,20 +22,20 @@ type OnrampProxy struct {
 // and an I2P or Onion address, and it will act as a tunnel to a
 // listening hidden service somewhere.
 func (p *OnrampProxy) Proxy(list net.Listener, raddr string) error {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"remote_address": raddr,
 		"local_address":  list.Addr().String(),
 	}).Debug("Starting proxy service")
 
 	for {
-		log.Debug("Waiting for incoming connection")
+		i2plog.Debug("Waiting for incoming connection")
 		conn, err := list.Accept()
 		if err != nil {
-			log.WithError(err).Error("Failed to accept connection")
+			i2plog.WithError(err).Error("Failed to accept connection")
 			return err
 		}
 
-		log.WithFields(logrus.Fields{
+		i2plog.WithFields(logrus.Fields{
 			"local_addr":  conn.LocalAddr().String(),
 			"remote_addr": conn.RemoteAddr().String(),
 		}).Debug("Accepted new connection, starting proxy routine")
@@ -45,7 +45,7 @@ func (p *OnrampProxy) Proxy(list net.Listener, raddr string) error {
 }
 
 func (p *OnrampProxy) proxy(conn net.Conn, raddr string) {
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"remote_address": raddr,
 		"local_addr":     conn.LocalAddr().String(),
 		"remote_addr":    conn.RemoteAddr().String(),
@@ -55,22 +55,22 @@ func (p *OnrampProxy) proxy(conn net.Conn, raddr string) {
 	var err error
 	checkaddr := strings.Split(raddr, ":")[0]
 	if strings.HasSuffix(checkaddr, ".i2p") {
-		log.Debug("Detected I2P address, using Garlic connection")
+		i2plog.Debug("Detected I2P address, using Garlic connection")
 		remote, err = p.Garlic.Dial("tcp", raddr)
 	} else if strings.HasSuffix(checkaddr, ".onion") {
-		log.Debug("Detected Onion address, using Tor connection")
+		i2plog.Debug("Detected Onion address, using Tor connection")
 		remote, err = p.Onion.Dial("tcp", raddr)
 	} else {
-		log.Debug("Using standard TCP connection")
+		i2plog.Debug("Using standard TCP connection")
 		remote, err = net.Dial("tcp", raddr)
 	}
 	if err != nil {
-		log.WithError(err).Error("Failed to establish remote connection")
-		log.Fatal("Cannot dial to remote")
+		i2plog.WithError(err).Error("Failed to establish remote connection")
+		i2plog.Fatal("Cannot dial to remote")
 	}
 	defer remote.Close()
 
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"local_addr":  remote.LocalAddr().String(),
 		"remote_addr": remote.RemoteAddr().String(),
 	}).Debug("Remote connection established, starting bidirectional copy")

--- a/proxy.go
+++ b/proxy.go
@@ -22,20 +22,20 @@ type OnrampProxy struct {
 // and an I2P or Onion address, and it will act as a tunnel to a
 // listening hidden service somewhere.
 func (p *OnrampProxy) Proxy(list net.Listener, raddr string) error {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"remote_address": raddr,
 		"local_address":  list.Addr().String(),
 	}).Debug("Starting proxy service")
 
 	for {
-		i2plog.Debug("Waiting for incoming connection")
+		i2pLogger.Debug("Waiting for incoming connection")
 		conn, err := list.Accept()
 		if err != nil {
-			i2plog.WithError(err).Error("Failed to accept connection")
+			i2pLogger.WithError(err).Error("Failed to accept connection")
 			return err
 		}
 
-		i2plog.WithFields(logrus.Fields{
+		i2pLogger.WithFields(logrus.Fields{
 			"local_addr":  conn.LocalAddr().String(),
 			"remote_addr": conn.RemoteAddr().String(),
 		}).Debug("Accepted new connection, starting proxy routine")
@@ -45,7 +45,7 @@ func (p *OnrampProxy) Proxy(list net.Listener, raddr string) error {
 }
 
 func (p *OnrampProxy) proxy(conn net.Conn, raddr string) {
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"remote_address": raddr,
 		"local_addr":     conn.LocalAddr().String(),
 		"remote_addr":    conn.RemoteAddr().String(),
@@ -55,22 +55,22 @@ func (p *OnrampProxy) proxy(conn net.Conn, raddr string) {
 	var err error
 	checkaddr := strings.Split(raddr, ":")[0]
 	if strings.HasSuffix(checkaddr, ".i2p") {
-		i2plog.Debug("Detected I2P address, using Garlic connection")
+		i2pLogger.Debug("Detected I2P address, using Garlic connection")
 		remote, err = p.Garlic.Dial("tcp", raddr)
 	} else if strings.HasSuffix(checkaddr, ".onion") {
-		i2plog.Debug("Detected Onion address, using Tor connection")
+		i2pLogger.Debug("Detected Onion address, using Tor connection")
 		remote, err = p.Onion.Dial("tcp", raddr)
 	} else {
-		i2plog.Debug("Using standard TCP connection")
+		i2pLogger.Debug("Using standard TCP connection")
 		remote, err = net.Dial("tcp", raddr)
 	}
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to establish remote connection")
-		i2plog.Fatal("Cannot dial to remote")
+		i2pLogger.WithError(err).Error("Failed to establish remote connection")
+		i2pLogger.Fatal("Cannot dial to remote")
 	}
 	defer remote.Close()
 
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"local_addr":  remote.LocalAddr().String(),
 		"remote_addr": remote.RemoteAddr().String(),
 	}).Debug("Remote connection established, starting bidirectional copy")

--- a/tls.go
+++ b/tls.go
@@ -26,14 +26,14 @@ import (
 // if no TLS keys exist, they will be generated. They will be valid for
 // the .b32.i2p domain.
 func (g *Garlic) TLSKeys() (tls.Certificate, error) {
-	log.WithField("name", g.getName()).Debug("Getting TLS keys for Garlic service")
+	i2plog.WithField("name", g.getName()).Debug("Getting TLS keys for Garlic service")
 	keys, err := g.Keys()
 	if err != nil {
-		log.WithError(err).Error("Failed to get I2P keys")
+		i2plog.WithError(err).Error("Failed to get I2P keys")
 		return tls.Certificate{}, err
 	}
 	base32 := keys.Addr().Base32()
-	log.WithField("base32", base32).Debug("Retrieving TLS certificate for base32 address")
+	i2plog.WithField("base32", base32).Debug("Retrieving TLS certificate for base32 address")
 	return TLSKeys(base32)
 }
 
@@ -41,45 +41,45 @@ func (g *Garlic) TLSKeys() (tls.Certificate, error) {
 // if no TLS keys exist, they will be generated. They will be valid for
 // the .onion domain.
 func (o *Onion) TLSKeys() (tls.Certificate, error) {
-	log.WithField("name", o.getName()).Debug("Getting TLS keys for Onion service")
+	i2plog.WithField("name", o.getName()).Debug("Getting TLS keys for Onion service")
 	keys, err := o.Keys()
 	if err != nil {
 		return tls.Certificate{}, err
 	}
 	onionService := torutil.OnionServiceIDFromPrivateKey(keys)
-	log.WithField("onion_service", onionService).Debug("Retrieving TLS certificate for onion service")
+	i2plog.WithField("onion_service", onionService).Debug("Retrieving TLS certificate for onion service")
 	return TLSKeys(onionService)
 }
 
 // TLSKeys returns the TLS certificate and key for the given hostname.
 func TLSKeys(tlsHost string) (tls.Certificate, error) {
-	log.WithField("host", tlsHost).Debug("Getting TLS certificate and key")
+	i2plog.WithField("host", tlsHost).Debug("Getting TLS certificate and key")
 	tlsCert := tlsHost + ".crt"
 	tlsKey := tlsHost + ".pem"
 	if err := CreateTLSCertificate(tlsHost); nil != err {
-		log.WithError(err).Error("Failed to create TLS certificate")
+		i2plog.WithError(err).Error("Failed to create TLS certificate")
 		return tls.Certificate{}, err
 	}
 	tlsKeystorePath, err := TLSKeystorePath()
 	if err != nil {
-		log.WithError(err).Error("Failed to get TLS keystore path")
+		i2plog.WithError(err).Error("Failed to get TLS keystore path")
 		return tls.Certificate{}, err
 	}
 	tlsCertPath := filepath.Join(tlsKeystorePath, tlsCert)
 	tlsKeyPath := filepath.Join(tlsKeystorePath, tlsKey)
 
-	log.WithFields(logrus.Fields{
+	i2plog.WithFields(logrus.Fields{
 		"cert_path": tlsCertPath,
 		"key_path":  tlsKeyPath,
 	}).Debug("Loading TLS certificate pair")
 
 	cert, err := tls.LoadX509KeyPair(tlsCertPath, tlsKeyPath)
 	if err != nil {
-		log.WithError(err).Error("Failed to load TLS certificate pair")
+		i2plog.WithError(err).Error("Failed to load TLS certificate pair")
 		return cert, err
 	}
 
-	log.Debug("Successfully loaded TLS certificate and key")
+	i2plog.Debug("Successfully loaded TLS certificate and key")
 	return cert, nil
 }
 
@@ -87,7 +87,7 @@ func TLSKeys(tlsHost string) (tls.Certificate, error) {
 // and stores it in the TLS keystore for the application. If the keys already
 // exist, generation is skipped.
 func CreateTLSCertificate(tlsHost string) error {
-	log.WithField("host", tlsHost).Debug("Creating TLS certificate")
+	i2plog.WithField("host", tlsHost).Debug("Creating TLS certificate")
 	tlsCertName := tlsHost + ".crt"
 	tlsKeyName := tlsHost + ".pem"
 	tlsKeystorePath, err := TLSKeystorePath()
@@ -99,102 +99,102 @@ func CreateTLSCertificate(tlsHost string) error {
 	_, certErr := os.Stat(tlsCert)
 	_, keyErr := os.Stat(tlsKey)
 	if certErr != nil || keyErr != nil {
-		log.WithFields(logrus.Fields{
+		i2plog.WithFields(logrus.Fields{
 			"cert_exists": certErr == nil,
 			"key_exists":  keyErr == nil,
 			"cert_path":   tlsCert,
 			"key_path":    tlsKey,
 		}).Debug("Certificate or key missing, generating new ones")
 		if certErr != nil {
-			log.WithField("path", tlsCert).Debug("TLS certificate not found")
+			i2plog.WithField("path", tlsCert).Debug("TLS certificate not found")
 			fmt.Printf("Unable to read TLS certificate '%s'\n", tlsCert)
 		}
 		if keyErr != nil {
-			log.WithField("path", tlsKey).Debug("TLS key not found")
+			i2plog.WithField("path", tlsKey).Debug("TLS key not found")
 			fmt.Printf("Unable to read TLS key '%s'\n", tlsKey)
 		}
 
 		if err := createTLSCertificate(tlsHost); nil != err {
-			log.WithError(err).Error("Failed to create TLS certificate")
+			i2plog.WithError(err).Error("Failed to create TLS certificate")
 			return err
 		}
 	} else {
-		log.Debug("TLS certificate and key already exist")
+		i2plog.Debug("TLS certificate and key already exist")
 	}
 
 	return nil
 }
 
 func createTLSCertificate(host string) error {
-	log.WithField("host", host).Debug("Generating new TLS certificate")
+	i2plog.WithField("host", host).Debug("Generating new TLS certificate")
 	fmt.Println("Generating TLS keys. This may take a minute...")
 	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		log.WithError(err).Error("Failed to generate private key")
+		i2plog.WithError(err).Error("Failed to generate private key")
 		return err
 	}
 
 	tlsCert, err := NewTLSCertificate(host, priv)
 	if nil != err {
-		log.WithError(err).Error("Failed to create new TLS certificate")
+		i2plog.WithError(err).Error("Failed to create new TLS certificate")
 		return err
 	}
 	privStore, err := TLSKeystorePath()
 	if nil != err {
-		log.WithError(err).Error("Failed to get keystore path")
+		i2plog.WithError(err).Error("Failed to get keystore path")
 		return err
 	}
 
 	certFile := filepath.Join(privStore, host+".crt")
-	log.WithField("path", certFile).Debug("Saving TLS certificate")
+	i2plog.WithField("path", certFile).Debug("Saving TLS certificate")
 	// save the TLS certificate
 	certOut, err := os.Create(certFile)
 	if err != nil {
-		log.WithError(err).WithField("path", certFile).Error("Failed to create certificate file")
+		i2plog.WithError(err).WithField("path", certFile).Error("Failed to create certificate file")
 		return fmt.Errorf("failed to open %s for writing: %s", host+".crt", err)
 	}
 	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: tlsCert})
 	certOut.Close()
-	log.WithField("path", certFile).Debug("TLS certificate saved successfully")
+	i2plog.WithField("path", certFile).Debug("TLS certificate saved successfully")
 	fmt.Printf("\tTLS certificate saved to: %s\n", host+".crt")
 
 	// save the TLS private key
 	privFile := filepath.Join(privStore, host+".pem")
-	log.WithField("path", privFile).Debug("Saving TLS private key")
+	i2plog.WithField("path", privFile).Debug("Saving TLS private key")
 	keyOut, err := os.OpenFile(privFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		log.WithError(err).WithField("path", privFile).Error("Failed to create private key file")
+		i2plog.WithError(err).WithField("path", privFile).Error("Failed to create private key file")
 		return fmt.Errorf("failed to open %s for writing: %v", privFile, err)
 	}
 	secp384r1, err := asn1.Marshal(asn1.ObjectIdentifier{1, 3, 132, 0, 34}) // http://www.ietf.org/rfc/rfc5480.txt
 	if err != nil {
-		log.WithError(err).Error("Failed to marshal EC parameters")
+		i2plog.WithError(err).Error("Failed to marshal EC parameters")
 		return err
 	}
 	pem.Encode(keyOut, &pem.Block{Type: "EC PARAMETERS", Bytes: secp384r1})
 	ecder, err := x509.MarshalECPrivateKey(priv)
 	if err != nil {
-		log.WithError(err).Error("Failed to marshal private key")
+		i2plog.WithError(err).Error("Failed to marshal private key")
 		return err
 	}
 	pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ecder})
 	pem.Encode(keyOut, &pem.Block{Type: "CERTIFICATE", Bytes: tlsCert})
 
 	keyOut.Close()
-	log.WithField("path", privFile).Debug("TLS private key saved successfully")
+	i2plog.WithField("path", privFile).Debug("TLS private key saved successfully")
 	fmt.Printf("\tTLS private key saved to: %s\n", privFile)
 
 	// CRL
 	crlFile := filepath.Join(privStore, host+".crl")
-	log.WithField("path", crlFile).Debug("Creating CRL")
+	i2plog.WithField("path", crlFile).Debug("Creating CRL")
 	crlOut, err := os.OpenFile(crlFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		log.WithError(err).WithField("path", crlFile).Error("Failed to create CRL file")
+		i2plog.WithError(err).WithField("path", crlFile).Error("Failed to create CRL file")
 		return fmt.Errorf("failed to open %s for writing: %s", crlFile, err)
 	}
 	crlcert, err := x509.ParseCertificate(tlsCert)
 	if err != nil {
-		log.WithError(err).Error("Failed to parse certificate for CRL creation")
+		i2plog.WithError(err).Error("Failed to parse certificate for CRL creation")
 		return fmt.Errorf("Certificate with unknown critical extension was not parsed: %s", err)
 	}
 
@@ -208,12 +208,12 @@ func createTLSCertificate(host string) error {
 
 	crlBytes, err := crlcert.CreateCRL(rand.Reader, priv, revokedCerts, now, now)
 	if err != nil {
-		log.WithError(err).Error("Failed to create CRL")
+		i2plog.WithError(err).Error("Failed to create CRL")
 		return fmt.Errorf("error creating CRL: %s", err)
 	}
 	_, err = x509.ParseDERCRL(crlBytes)
 	if err != nil {
-		log.WithError(err).Error("Failed to validate generated CRL")
+		i2plog.WithError(err).Error("Failed to validate generated CRL")
 		return fmt.Errorf("error reparsing CRL: %s", err)
 	}
 	pem.Encode(crlOut, &pem.Block{Type: "X509 CRL", Bytes: crlBytes})

--- a/tls.go
+++ b/tls.go
@@ -26,14 +26,14 @@ import (
 // if no TLS keys exist, they will be generated. They will be valid for
 // the .b32.i2p domain.
 func (g *Garlic) TLSKeys() (tls.Certificate, error) {
-	i2plog.WithField("name", g.getName()).Debug("Getting TLS keys for Garlic service")
+	i2pLogger.WithField("name", g.getName()).Debug("Getting TLS keys for Garlic service")
 	keys, err := g.Keys()
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to get I2P keys")
+		i2pLogger.WithError(err).Error("Failed to get I2P keys")
 		return tls.Certificate{}, err
 	}
 	base32 := keys.Addr().Base32()
-	i2plog.WithField("base32", base32).Debug("Retrieving TLS certificate for base32 address")
+	i2pLogger.WithField("base32", base32).Debug("Retrieving TLS certificate for base32 address")
 	return TLSKeys(base32)
 }
 
@@ -41,45 +41,45 @@ func (g *Garlic) TLSKeys() (tls.Certificate, error) {
 // if no TLS keys exist, they will be generated. They will be valid for
 // the .onion domain.
 func (o *Onion) TLSKeys() (tls.Certificate, error) {
-	i2plog.WithField("name", o.getName()).Debug("Getting TLS keys for Onion service")
+	i2pLogger.WithField("name", o.getName()).Debug("Getting TLS keys for Onion service")
 	keys, err := o.Keys()
 	if err != nil {
 		return tls.Certificate{}, err
 	}
 	onionService := torutil.OnionServiceIDFromPrivateKey(keys)
-	i2plog.WithField("onion_service", onionService).Debug("Retrieving TLS certificate for onion service")
+	i2pLogger.WithField("onion_service", onionService).Debug("Retrieving TLS certificate for onion service")
 	return TLSKeys(onionService)
 }
 
 // TLSKeys returns the TLS certificate and key for the given hostname.
 func TLSKeys(tlsHost string) (tls.Certificate, error) {
-	i2plog.WithField("host", tlsHost).Debug("Getting TLS certificate and key")
+	i2pLogger.WithField("host", tlsHost).Debug("Getting TLS certificate and key")
 	tlsCert := tlsHost + ".crt"
 	tlsKey := tlsHost + ".pem"
 	if err := CreateTLSCertificate(tlsHost); nil != err {
-		i2plog.WithError(err).Error("Failed to create TLS certificate")
+		i2pLogger.WithError(err).Error("Failed to create TLS certificate")
 		return tls.Certificate{}, err
 	}
 	tlsKeystorePath, err := TLSKeystorePath()
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to get TLS keystore path")
+		i2pLogger.WithError(err).Error("Failed to get TLS keystore path")
 		return tls.Certificate{}, err
 	}
 	tlsCertPath := filepath.Join(tlsKeystorePath, tlsCert)
 	tlsKeyPath := filepath.Join(tlsKeystorePath, tlsKey)
 
-	i2plog.WithFields(logrus.Fields{
+	i2pLogger.WithFields(logrus.Fields{
 		"cert_path": tlsCertPath,
 		"key_path":  tlsKeyPath,
 	}).Debug("Loading TLS certificate pair")
 
 	cert, err := tls.LoadX509KeyPair(tlsCertPath, tlsKeyPath)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to load TLS certificate pair")
+		i2pLogger.WithError(err).Error("Failed to load TLS certificate pair")
 		return cert, err
 	}
 
-	i2plog.Debug("Successfully loaded TLS certificate and key")
+	i2pLogger.Debug("Successfully loaded TLS certificate and key")
 	return cert, nil
 }
 
@@ -87,7 +87,7 @@ func TLSKeys(tlsHost string) (tls.Certificate, error) {
 // and stores it in the TLS keystore for the application. If the keys already
 // exist, generation is skipped.
 func CreateTLSCertificate(tlsHost string) error {
-	i2plog.WithField("host", tlsHost).Debug("Creating TLS certificate")
+	i2pLogger.WithField("host", tlsHost).Debug("Creating TLS certificate")
 	tlsCertName := tlsHost + ".crt"
 	tlsKeyName := tlsHost + ".pem"
 	tlsKeystorePath, err := TLSKeystorePath()
@@ -99,102 +99,102 @@ func CreateTLSCertificate(tlsHost string) error {
 	_, certErr := os.Stat(tlsCert)
 	_, keyErr := os.Stat(tlsKey)
 	if certErr != nil || keyErr != nil {
-		i2plog.WithFields(logrus.Fields{
+		i2pLogger.WithFields(logrus.Fields{
 			"cert_exists": certErr == nil,
 			"key_exists":  keyErr == nil,
 			"cert_path":   tlsCert,
 			"key_path":    tlsKey,
 		}).Debug("Certificate or key missing, generating new ones")
 		if certErr != nil {
-			i2plog.WithField("path", tlsCert).Debug("TLS certificate not found")
+			i2pLogger.WithField("path", tlsCert).Debug("TLS certificate not found")
 			fmt.Printf("Unable to read TLS certificate '%s'\n", tlsCert)
 		}
 		if keyErr != nil {
-			i2plog.WithField("path", tlsKey).Debug("TLS key not found")
+			i2pLogger.WithField("path", tlsKey).Debug("TLS key not found")
 			fmt.Printf("Unable to read TLS key '%s'\n", tlsKey)
 		}
 
 		if err := createTLSCertificate(tlsHost); nil != err {
-			i2plog.WithError(err).Error("Failed to create TLS certificate")
+			i2pLogger.WithError(err).Error("Failed to create TLS certificate")
 			return err
 		}
 	} else {
-		i2plog.Debug("TLS certificate and key already exist")
+		i2pLogger.Debug("TLS certificate and key already exist")
 	}
 
 	return nil
 }
 
 func createTLSCertificate(host string) error {
-	i2plog.WithField("host", host).Debug("Generating new TLS certificate")
+	i2pLogger.WithField("host", host).Debug("Generating new TLS certificate")
 	fmt.Println("Generating TLS keys. This may take a minute...")
 	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to generate private key")
+		i2pLogger.WithError(err).Error("Failed to generate private key")
 		return err
 	}
 
 	tlsCert, err := NewTLSCertificate(host, priv)
 	if nil != err {
-		i2plog.WithError(err).Error("Failed to create new TLS certificate")
+		i2pLogger.WithError(err).Error("Failed to create new TLS certificate")
 		return err
 	}
 	privStore, err := TLSKeystorePath()
 	if nil != err {
-		i2plog.WithError(err).Error("Failed to get keystore path")
+		i2pLogger.WithError(err).Error("Failed to get keystore path")
 		return err
 	}
 
 	certFile := filepath.Join(privStore, host+".crt")
-	i2plog.WithField("path", certFile).Debug("Saving TLS certificate")
+	i2pLogger.WithField("path", certFile).Debug("Saving TLS certificate")
 	// save the TLS certificate
 	certOut, err := os.Create(certFile)
 	if err != nil {
-		i2plog.WithError(err).WithField("path", certFile).Error("Failed to create certificate file")
+		i2pLogger.WithError(err).WithField("path", certFile).Error("Failed to create certificate file")
 		return fmt.Errorf("failed to open %s for writing: %s", host+".crt", err)
 	}
 	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: tlsCert})
 	certOut.Close()
-	i2plog.WithField("path", certFile).Debug("TLS certificate saved successfully")
+	i2pLogger.WithField("path", certFile).Debug("TLS certificate saved successfully")
 	fmt.Printf("\tTLS certificate saved to: %s\n", host+".crt")
 
 	// save the TLS private key
 	privFile := filepath.Join(privStore, host+".pem")
-	i2plog.WithField("path", privFile).Debug("Saving TLS private key")
+	i2pLogger.WithField("path", privFile).Debug("Saving TLS private key")
 	keyOut, err := os.OpenFile(privFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		i2plog.WithError(err).WithField("path", privFile).Error("Failed to create private key file")
+		i2pLogger.WithError(err).WithField("path", privFile).Error("Failed to create private key file")
 		return fmt.Errorf("failed to open %s for writing: %v", privFile, err)
 	}
 	secp384r1, err := asn1.Marshal(asn1.ObjectIdentifier{1, 3, 132, 0, 34}) // http://www.ietf.org/rfc/rfc5480.txt
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to marshal EC parameters")
+		i2pLogger.WithError(err).Error("Failed to marshal EC parameters")
 		return err
 	}
 	pem.Encode(keyOut, &pem.Block{Type: "EC PARAMETERS", Bytes: secp384r1})
 	ecder, err := x509.MarshalECPrivateKey(priv)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to marshal private key")
+		i2pLogger.WithError(err).Error("Failed to marshal private key")
 		return err
 	}
 	pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ecder})
 	pem.Encode(keyOut, &pem.Block{Type: "CERTIFICATE", Bytes: tlsCert})
 
 	keyOut.Close()
-	i2plog.WithField("path", privFile).Debug("TLS private key saved successfully")
+	i2pLogger.WithField("path", privFile).Debug("TLS private key saved successfully")
 	fmt.Printf("\tTLS private key saved to: %s\n", privFile)
 
 	// CRL
 	crlFile := filepath.Join(privStore, host+".crl")
-	i2plog.WithField("path", crlFile).Debug("Creating CRL")
+	i2pLogger.WithField("path", crlFile).Debug("Creating CRL")
 	crlOut, err := os.OpenFile(crlFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		i2plog.WithError(err).WithField("path", crlFile).Error("Failed to create CRL file")
+		i2pLogger.WithError(err).WithField("path", crlFile).Error("Failed to create CRL file")
 		return fmt.Errorf("failed to open %s for writing: %s", crlFile, err)
 	}
 	crlcert, err := x509.ParseCertificate(tlsCert)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to parse certificate for CRL creation")
+		i2pLogger.WithError(err).Error("Failed to parse certificate for CRL creation")
 		return fmt.Errorf("Certificate with unknown critical extension was not parsed: %s", err)
 	}
 
@@ -208,12 +208,12 @@ func createTLSCertificate(host string) error {
 
 	crlBytes, err := crlcert.CreateCRL(rand.Reader, priv, revokedCerts, now, now)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to create CRL")
+		i2pLogger.WithError(err).Error("Failed to create CRL")
 		return fmt.Errorf("error creating CRL: %s", err)
 	}
 	_, err = x509.ParseDERCRL(crlBytes)
 	if err != nil {
-		i2plog.WithError(err).Error("Failed to validate generated CRL")
+		i2pLogger.WithError(err).Error("Failed to validate generated CRL")
 		return fmt.Errorf("error reparsing CRL: %s", err)
 	}
 	pem.Encode(crlOut, &pem.Block{Type: "X509 CRL", Bytes: crlBytes})


### PR DESCRIPTION
- Add a dependency on `github.com/go-i2p/logger`, turn `log.go` into a simple wrapper around it
- While I am here: bump go version, fix `io/ioutil` deprecations
- Most of the diff is just `s/log/2pLogger`